### PR TITLE
disabled handle quoting when executing command (#47)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/common/utils/ExecHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/utils/ExecHelper.java
@@ -69,7 +69,7 @@ public class ExecHelper {
     PumpStreamHandler handler = new PumpStreamHandler(new WriterOutputStream(writer));
     executor.setStreamHandler(handler);
     executor.setWorkingDirectory(workingDirectory);
-    CommandLine command = new CommandLine(executable).addArguments(arguments);
+    CommandLine command = new CommandLine(executable).addArguments(arguments, false);
     try {
       executor.execute(command);
       return writer.toString();


### PR DESCRIPTION
it fixes #47 
When starting  a task or a pipeline by passing a value with an empty space in it (like `key=bla bla`) the execHelper quotes it  `"key=bla bla"`. When executing the command the tkncli interpret `"key` as it is the name to use and look for in the pipeline. It doesn't find it and it prints an error