### PR TITLE
Fix for first release - part 1

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/common/CommonConstants.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/CommonConstants.java
@@ -17,4 +17,5 @@ public class CommonConstants {
     public static final String HOME_FOLDER = System.getProperty("user.home");
 
     public static final Key<Project> PROJECT = Key.create("project");
+    public static final Key<Long> LAST_MODIFICATION_STAMP = Key.create("last.modification.stamp");
 }

--- a/src/main/java/com/redhat/devtools/intellij/common/CommonConstants.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/CommonConstants.java
@@ -16,6 +16,6 @@ import com.intellij.openapi.util.Key;
 public class CommonConstants {
     public static final String HOME_FOLDER = System.getProperty("user.home");
 
-    public static final Key<Project> PROJECT = Key.create("project");
-    public static final Key<Long> LAST_MODIFICATION_STAMP = Key.create("last.modification.stamp");
+    public static final Key<Project> PROJECT = Key.create("com.redhat.devtools.intellij.common.project");
+    public static final Key<Long> LAST_MODIFICATION_STAMP = Key.create("com.redhat.devtools.intellij.common.last.modification.stamp");
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/Constants.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/Constants.java
@@ -14,7 +14,7 @@ import com.intellij.openapi.util.Key;
 
 public class Constants {
     public static final String NOTIFICATION_ID = "Tekton Pipelines";
-    public static final Key<String> KIND_PLURAL = Key.create("tekton.plural");
+    public static final Key<String> KIND_PLURAL = Key.create("com.redhat.devtools.intellij.tektoncd.tekton.plural");
 
     public static final String KIND_CLUSTERTASKS = "clustertasks";
     public static final String KIND_PIPELINES = "pipelines";

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/StartAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/StartAction.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.swing.tree.TreePath;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -82,12 +83,13 @@ public class StartAction extends TektonAction {
             }
             if (noInputsAndOuputs || stdialog.isOK()) {
                 try {
-                    Map<String, String> params = stdialog == null ? null : stdialog.getParameters();
-                    Map<String, String> inputResources = stdialog == null ? null : stdialog.getInputResources();
+                    Map<String, String> params = stdialog == null ? Collections.emptyMap() : stdialog.getParameters();
+                    Map<String, String> inputResources = stdialog == null ? Collections.emptyMap() : stdialog.getInputResources();
+                    Map<String, String> outputResources = stdialog == null ? Collections.emptyMap() : stdialog.getOutputResources();
                     if (PipelineNode.class.equals(nodeClass)) {
                         tkncli.startPipeline(namespace, selected.toString(), params, inputResources);
                     } else if (TaskNode.class.equals(nodeClass)) {
-                        tkncli.startTask(namespace, selected.toString(), params, inputResources, stdialog.getOutputResources());
+                        tkncli.startTask(namespace, selected.toString(), params, inputResources, outputResources);
                     }
                     ((LazyMutableTreeNode)selected).reload();
                 } catch (IOException e) {

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/listener/SaveInEditorListener.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/listener/SaveInEditorListener.java
@@ -61,7 +61,7 @@ public class SaveInEditorListener extends FileDocumentSynchronizationVetoer {
         Long currentModificationStamp = document.getModificationStamp();
         if(project == null ||
                  !isFileToPush(project, document, vf) ||
-                 (lastModificationStamp != null && lastModificationStamp != currentModificationStamp)
+                 (lastModificationStamp != null && lastModificationStamp.longValue() == currentModificationStamp.longValue())
         ) {
             return true;
         }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/listener/SaveInEditorListener.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/listener/SaveInEditorListener.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Map;
 
+import static com.redhat.devtools.intellij.common.CommonConstants.LAST_MODIFICATION_STAMP;
 import static com.redhat.devtools.intellij.common.CommonConstants.PROJECT;
 import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_CLUSTERTASKS;
 import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_PLURAL;
@@ -56,7 +57,15 @@ public class SaveInEditorListener extends FileDocumentSynchronizationVetoer {
     public boolean maySaveDocument(@NotNull Document document, boolean isSaveExplicit) {
         VirtualFile vf = FileDocumentManager.getInstance().getFile(document);
         Project project = vf.getUserData(PROJECT);
-        if(project == null || !isFileToPush(project, document, vf)) return true;
+        Long lastModificationStamp = vf.getUserData(LAST_MODIFICATION_STAMP);
+        Long currentModificationStamp = document.getModificationStamp();
+        if(project == null ||
+                 !isFileToPush(project, document, vf) ||
+                 (lastModificationStamp != null && lastModificationStamp != currentModificationStamp)
+        ) {
+            return true;
+        }
+        vf.putUserData(LAST_MODIFICATION_STAMP, currentModificationStamp);
 
         String namespace, name, apiVersion;
         JsonNode spec;

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/listener/SaveInEditorListener.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/listener/SaveInEditorListener.java
@@ -61,7 +61,7 @@ public class SaveInEditorListener extends FileDocumentSynchronizationVetoer {
         Long currentModificationStamp = document.getModificationStamp();
         if(project == null ||
                  !isFileToPush(project, document, vf) ||
-                 (lastModificationStamp != null && currentModificationStamp.equals(lastModificationStamp))
+                 currentModificationStamp.equals(lastModificationStamp)
         ) {
             return true;
         }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/listener/SaveInEditorListener.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/listener/SaveInEditorListener.java
@@ -61,7 +61,7 @@ public class SaveInEditorListener extends FileDocumentSynchronizationVetoer {
         Long currentModificationStamp = document.getModificationStamp();
         if(project == null ||
                  !isFileToPush(project, document, vf) ||
-                 (lastModificationStamp != null && lastModificationStamp.longValue() == currentModificationStamp.longValue())
+                 (lastModificationStamp != null && currentModificationStamp.equals(lastModificationStamp))
         ) {
             return true;
         }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/component/field/Input.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/component/field/Input.java
@@ -12,10 +12,10 @@ package com.redhat.devtools.intellij.tektoncd.tkn.component.field;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import org.apache.commons.lang.StringUtils;
 
-import java.util.Iterator;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public class Input {
 
@@ -87,13 +87,7 @@ public class Input {
     }
 
     private String convertArrayNodeToString(ArrayNode node) {
-        String result = "";
-        for (Iterator<JsonNode> it = node.iterator(); it.hasNext(); ) {
-            JsonNode item = it.next();
-            result += item.asText() + ",";
-        }
-        result = result.equals("") ? result : StringUtils.removeEnd(result, ",");
-        return result;
+        return  StreamSupport.stream(node.spliterator(), false).map(jsonNode -> jsonNode.asText()).collect(Collectors.joining(","));
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/component/field/Input.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/component/field/Input.java
@@ -11,7 +11,10 @@
 package com.redhat.devtools.intellij.tektoncd.tkn.component.field;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.commons.lang.StringUtils;
 
+import java.util.Iterator;
 import java.util.Optional;
 
 public class Input {
@@ -71,6 +74,9 @@ public class Input {
         JsonNode defaultItem = inputNode.get("default");
         if (defaultItem != null) {
             defaultValue = Optional.of(defaultItem.asText());
+            if (defaultItem.isArray()) {
+                defaultValue = Optional.of(convertArrayNodeToString((ArrayNode) defaultItem));
+            }
         }
         this.name = name;
         this.type = type;
@@ -78,6 +84,16 @@ public class Input {
         this.description = description;
         this.kind = kind;
         return this;
+    }
+
+    private String convertArrayNodeToString(ArrayNode node) {
+        String result = "";
+        for (Iterator<JsonNode> it = node.iterator(); it.hasNext(); ) {
+            JsonNode item = it.next();
+            result += item.asText() + ",";
+        }
+        result = result.equals("") ? result : StringUtils.removeEnd(result, ",");
+        return result;
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/StartDialog.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/StartDialog.java
@@ -277,9 +277,6 @@ public class StartDialog extends DialogWrapper {
     private void setInputValue(String inputName, String value) {
         for (Input input: inputs) {
             if (input.name().equals(inputName)) {
-                if (input.type().equals("array")) {
-                    value = value.replace(" ", ",");
-                }
                 input.setValue(value);
                 break;
             }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/StartResourceModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/StartResourceModel.java
@@ -1,0 +1,213 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Strings;
+import com.redhat.devtools.intellij.common.utils.YAMLHelper;
+import com.redhat.devtools.intellij.tektoncd.tkn.Resource;
+import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
+import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Output;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_PIPELINE;
+
+public class StartResourceModel {
+
+    private String namespace, name, kind;
+    private List<Input> inputs;
+    private List<Output> outputs;
+    private List<Resource> resources;
+    private boolean isValid = true;
+    private String errorMessage;
+
+    public StartResourceModel(String configuration, List<Resource> resources) {
+        this.resources = resources;
+        this.errorMessage = "Tekton configuration has an invalid format:\n";
+        buildModel(configuration);
+    }
+
+    private void buildModel(String configuration) {
+        try {
+            this.namespace = YAMLHelper.getStringValueFromYAML(configuration, new String[] {"metadata", "namespace"});
+            if (Strings.isNullOrEmpty(namespace)) {
+                errorMessage += " * Namespace field is missing or its value is not valid.\n";
+                isValid = false;
+            }
+            this.name = YAMLHelper.getStringValueFromYAML(configuration, new String[] {"metadata", "name"});
+            if (Strings.isNullOrEmpty(this.name)) {
+                errorMessage += " * Name field is missing or its value is not valid.\n";
+                isValid = false;
+            }
+            this.kind = YAMLHelper.getStringValueFromYAML(configuration, new String[] {"kind"});
+            if (Strings.isNullOrEmpty(kind)) {
+                errorMessage += " * Kind field is missing or its value is not valid.\n";
+                isValid = false;
+            }
+            buildInputs(configuration);
+            buildOutputs(configuration);
+
+            // if for a specific input/output type (git, image, ...) only a resource exists, set that resource as default value for input/output
+            setDefaultValueResources();
+        } catch (IOException e) {
+            errorMessage += " Error: " + e.getLocalizedMessage() + "\n";
+            isValid = false;
+        }
+    }
+
+    private void buildInputs(String configuration) throws IOException {
+        if (isPipeline()) {
+            JsonNode inputsNode = YAMLHelper.getValueFromYAML(configuration, new String[] {"spec"});
+            if (inputsNode != null) {
+                this.inputs = getInputsFromNode(inputsNode);
+            }
+        } else {
+            JsonNode inputsNode = YAMLHelper.getValueFromYAML(configuration, new String[]{"spec", "inputs"});
+            if (inputsNode != null) {
+                this.inputs = getInputsFromNode(inputsNode);
+            }
+        }
+    }
+
+    private void buildOutputs(String configuration) throws IOException {
+        if (!isPipeline()) {
+            JsonNode outputsNode = YAMLHelper.getValueFromYAML(configuration, new String[] {"spec", "outputs"});
+            if (outputsNode != null) {
+                this.outputs = getOutputs(outputsNode);
+            }
+        }
+    }
+
+    private void setDefaultValueResources() {
+        int resourcesCount;
+        List<Input> resourceInputs = null;
+        if (this.inputs != null) {
+            resourceInputs = inputs.stream().filter(input -> input.kind() == Input.Kind.RESOURCE).collect(Collectors.toList());
+        }
+
+        if (resourceInputs == null && this.outputs == null) {
+            return;
+        }
+
+        if (this.resources == null) {
+            errorMessage += " * The " + this.kind + " requires resources to be started but no resources were found in the cluster.\n";
+            isValid = false;
+        }
+
+        // if for a specific type (git, image, ...) only a resource exists, set that resource as default value for input/output
+        Map<String, List<Resource>> resourceGroupedByType = resources.stream().collect(Collectors.groupingBy(Resource::type));
+
+        for (Input input: resourceInputs) {
+            List<Resource> resourcesByInputType = resourceGroupedByType.get(input.type());
+            if (resourcesByInputType == null) {
+                errorMessage += " * The input " + input.name() + " requires a resource of type " + input.type() + " but no resource of that type was found in the cluster.\n";
+                isValid = false;
+                continue;
+            }
+            if (resourcesByInputType.size() == 1) {
+                input.setValue(resourcesByInputType.get(0).name());
+            }
+        }
+
+        if (outputs != null) {
+            for (Output output: outputs) {
+                List<Resource> resourcesByOutputType = resourceGroupedByType.get(output.type());
+                if (resourcesByOutputType == null) {
+                    errorMessage += " * The output " + output.name() + " requires a resource of type " + output.type() + " but no resource of that type was found in the cluster.\n";
+                    isValid = false;
+                    continue;
+                }
+                if (resourcesByOutputType.size() == 1) {
+                    output.setValue(resourcesByOutputType.get(0).name());
+                }
+            }
+        }
+
+    }
+
+    private List<Input> getInputsFromNode(JsonNode inputsNode) {
+        List<Input> result = new ArrayList<>();
+        JsonNode params = inputsNode.has("params") ? inputsNode.get("params") : null;
+        JsonNode resources = inputsNode.has("resources") ? inputsNode.get("resources") : null;
+
+        if (params != null) {
+            result.addAll(getInputsFromNodeInternal(params, Input.Kind.PARAMETER));
+        }
+
+        if (resources != null) {
+            result.addAll(getInputsFromNodeInternal(resources, Input.Kind.RESOURCE));
+        }
+
+        return result;
+    }
+
+    private List<Input> getInputsFromNodeInternal(JsonNode node, Input.Kind kind) {
+        List<Input> result = new ArrayList<>();
+        for (Iterator<JsonNode> it = node.elements(); it.hasNext(); ) {
+            JsonNode item = it.next();
+            result.add(new Input().fromJson(item, kind));
+        }
+        return result;
+    }
+
+    private List<Output> getOutputs(JsonNode outputsNode) {
+        List<Output> result = new ArrayList<>();
+        List<JsonNode> resources = outputsNode.findValues("resources");
+
+        if (resources != null) {
+            for (Iterator<JsonNode> it = resources.iterator(); it.hasNext(); ) {
+                JsonNode item = it.next();
+                result.add(new Output().fromJson(item.get(0)));
+            }
+        }
+
+        return result;
+    }
+
+    private boolean isPipeline() {
+        return KIND_PIPELINE.equalsIgnoreCase(this.kind);
+    }
+
+    public boolean isValid() {
+        return this.isValid;
+    }
+
+    public String getNamespace() {
+        return this.namespace;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getKind() {
+        return this.kind;
+    }
+
+    public List<Input> getInputs() {
+        return this.inputs;
+    }
+
+    public List<Output> getOutputs() {
+        return this.outputs;
+    }
+
+    public String getErrorMessage() {
+        return this.errorMessage;
+    }
+
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/StartResourceModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/StartResourceModel.java
@@ -93,7 +93,6 @@ public class StartResourceModel {
     }
 
     private void setDefaultValueResources() {
-        int resourcesCount;
         List<Input> resourceInputs = null;
         if (this.inputs != null) {
             resourceInputs = inputs.stream().filter(input -> input.kind() == Input.Kind.RESOURCE).collect(Collectors.toList());
@@ -152,7 +151,7 @@ public class StartResourceModel {
             result.addAll(getInputsFromNodeInternal(resources, Input.Kind.RESOURCE));
         }
 
-        return result;
+        return result.size() > 0 ? result : null;
     }
 
     private List<Input> getInputsFromNodeInternal(JsonNode node, Input.Kind kind) {
@@ -175,7 +174,7 @@ public class StartResourceModel {
             }
         }
 
-        return result;
+        return result.size() > 0 ? result : null;
     }
 
     private boolean isPipeline() {


### PR DESCRIPTION
@jeffmaury this PR contains almost all changes we discussed yesterday. The only missing one is go from logger.error to logger.warn which i'll cover when this PR will be released.

The timestamp for saving a file works. If you can test it on your IDE it would be great because i don't know why when i click on the terminal my autosave doesn't get triggered.

You told me that validate the model before opening the start dialog wasn't needed right now (and just disable the start btn) but i prefer to go that way because it also helped me solving another issue and it helps having a cleaner code. Also if we need to tackle betav1 soon, this refactor was almost mandatory.
With this, the dialog is not shown if there are no inputs or outputs (the task is started automatically) and an error is shown if the model is not valid. e.g.
![error-1](https://user-images.githubusercontent.com/49404737/78980253-d2418a00-7b1d-11ea-924a-f55d6353edcc.png)
