### PR TITLE
Added Pipelineruns and Taskruns node as root

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/RefreshAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/RefreshAction.java
@@ -15,9 +15,11 @@ import com.redhat.devtools.intellij.common.actions.StructureTreeAction;
 import com.redhat.devtools.intellij.tektoncd.Constants;
 import com.redhat.devtools.intellij.tektoncd.tree.ClusterTasksNode;
 import com.redhat.devtools.intellij.tektoncd.tree.PipelineNode;
+import com.redhat.devtools.intellij.tektoncd.tree.PipelineRunsNode;
 import com.redhat.devtools.intellij.tektoncd.tree.PipelinesNode;
 import com.redhat.devtools.intellij.tektoncd.tree.ResourcesNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TaskNode;
+import com.redhat.devtools.intellij.tektoncd.tree.TaskRunsNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TasksNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TektonTreeStructure;
 
@@ -25,7 +27,7 @@ import javax.swing.tree.TreePath;
 
 public class RefreshAction extends StructureTreeAction {
     public RefreshAction() {
-        super(PipelinesNode.class, TasksNode.class, ClusterTasksNode.class, ResourcesNode.class, PipelineNode.class, TaskNode.class);
+        super(PipelinesNode.class, TasksNode.class, ClusterTasksNode.class, ResourcesNode.class, PipelineNode.class, TaskNode.class, PipelineRunsNode.class, TaskRunsNode.class);
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/logs/LogsBaseAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/logs/LogsBaseAction.java
@@ -43,7 +43,7 @@ public abstract class LogsBaseAction extends TektonAction {
     public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Tkn tkncli) {
         ExecHelper.submit(() -> {
             ParentableNode element = getElement(selected);
-            String namespace = getNamespace(element);
+            String namespace = element.getNamespace();
             String resourceName = pickRun(namespace, element, anActionEvent.getPresentation().getText(), tkncli);
             if (resourceName == null) return;
 
@@ -125,16 +125,5 @@ public abstract class LogsBaseAction extends TektonAction {
         }
         return runPicked;
 
-    }
-
-    private String getNamespace(Object selected) {
-        while (selected != null && !(selected instanceof NamespaceNode)) {
-            if (selected instanceof ParentableNode) {
-                selected = ((ParentableNode)selected).getParent();
-            } else {
-                selected = null;
-            }
-        }
-        return selected != null ? ((NamespaceNode)selected).getName():"";
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tree/ParentableNode.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tree/ParentableNode.java
@@ -32,4 +32,16 @@ public abstract class ParentableNode<T> {
     public String getName() {
         return name;
     }
+
+    public String getNamespace() {
+        Object element = this;
+        while (!(element instanceof NamespaceNode)) {
+            if (element instanceof ParentableNode) {
+                element = ((ParentableNode)element).getParent();
+            } else {
+                element = null;
+            }
+        }
+        return element != null ? ((NamespaceNode)element).getName():"";
+    }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tree/PipelineRunsNode.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tree/PipelineRunsNode.java
@@ -10,10 +10,8 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.tektoncd.tree;
 
-import com.redhat.devtools.intellij.tektoncd.tkn.PipelineRun;
-
-public class PipelineRunNode extends RunNode<ParentableNode, PipelineRun> {
-    public PipelineRunNode(TektonRootNode root, ParentableNode parent, PipelineRun run) {
-        super(root, parent, run);
+public class PipelineRunsNode extends ParentableNode<NamespaceNode>  {
+    public PipelineRunsNode(TektonRootNode root, NamespaceNode parent) {
+        super(root, parent, "PipelineRuns");
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tree/TaskRunNode.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tree/TaskRunNode.java
@@ -14,7 +14,7 @@ import com.redhat.devtools.intellij.common.utils.StringHelper;
 import com.redhat.devtools.intellij.tektoncd.tkn.TaskRun;
 
 public class TaskRunNode extends RunNode {
-    public TaskRunNode(TektonRootNode root, ParentableNode<Object> parent, TaskRun run) {
+    public TaskRunNode(TektonRootNode root, ParentableNode parent, TaskRun run) {
         super(root, parent, run);
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tree/TaskRunsNode.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tree/TaskRunsNode.java
@@ -10,10 +10,8 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.tektoncd.tree;
 
-import com.redhat.devtools.intellij.tektoncd.tkn.PipelineRun;
-
-public class PipelineRunNode extends RunNode<ParentableNode, PipelineRun> {
-    public PipelineRunNode(TektonRootNode root, ParentableNode parent, PipelineRun run) {
-        super(root, parent, run);
+public class TaskRunsNode extends ParentableNode<NamespaceNode>  {
+    public TaskRunsNode(TektonRootNode root, NamespaceNode parent) {
+        super(root, parent, "TaskRuns");
     }
 }


### PR DESCRIPTION
it fixes #81 

Couple of question here. 
First is which icon i should use? I left the pipeline icon as default here because i opened https://github.com/redhat-developer/intellij-tekton/issues/72 and i'll move to different icons with that PR. Do we agree to use the icons from vscode?

Second, in vscode under the pipelineruns root node they only show the pipelineruns without being able to expand them and see their taskrun. In this PR it works differently and you can expand a pipelinerun and see its children. Do i have to change it?

![image](https://user-images.githubusercontent.com/49404737/80378196-9851e100-889c-11ea-9f5a-5e4f20fde27d.png)
