### PR TITLE
change how node is retrieved when creating new resource (#102)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/Constants.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/Constants.java
@@ -11,11 +11,13 @@
 package com.redhat.devtools.intellij.tektoncd;
 
 import com.intellij.openapi.util.Key;
+import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
 
 public class Constants {
     public static final String NOTIFICATION_ID = "Tekton Pipelines";
     public static final Key<String> NAMESPACE = Key.create("com.redhat.devtools.intellij.tektoncd.tekton.namespace");
     public static final Key<String> KIND_PLURAL = Key.create("com.redhat.devtools.intellij.tektoncd.tekton.plural");
+    public static final Key<ParentableNode> TARGET_NODE = Key.create("com.redhat.devtools.intellij.tektoncd.tekton.targetnode");
 
     public static final String KIND_CLUSTERTASKS = "clustertasks";
     public static final String KIND_PIPELINES = "pipelines";

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/OpenEditorAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/OpenEditorAction.java
@@ -96,7 +96,7 @@ public class OpenEditorAction extends TektonAction {
                     filter(fileEditor -> fileEditor.getFile().getName().startsWith(namespace + "-" + element.getName()) &&
                             fileEditor.getFile().getExtension().equals("yaml")).findFirst();
             if (!editor.isPresent()) {
-                createAndOpenVirtualFile(project, namespace, namespace + "-" + element.getName() + ".yaml", content, kind);
+                createAndOpenVirtualFile(project, namespace, namespace + "-" + element.getName() + ".yaml", content, kind, null);
             } else {
                 FileEditorManager.getInstance(project).openTextEditor(new OpenFileDescriptor(project, editor.get().getFile()), true);
             }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/TektonAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/TektonAction.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.tektoncd.actions;
 
-import com.google.common.base.Strings;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
@@ -21,6 +20,7 @@ import com.intellij.ui.treeStructure.Tree;
 import com.redhat.devtools.intellij.common.actions.StructureTreeAction;
 import com.redhat.devtools.intellij.tektoncd.Constants;
 import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
+import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TektonRootNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TektonTreeStructure;
 import com.redhat.devtools.intellij.tektoncd.utils.SnippetHelper;
@@ -36,6 +36,7 @@ import java.nio.charset.StandardCharsets;
 import static com.redhat.devtools.intellij.common.CommonConstants.PROJECT;
 import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_PLURAL;
 import static com.redhat.devtools.intellij.tektoncd.Constants.NAMESPACE;
+import static com.redhat.devtools.intellij.tektoncd.Constants.TARGET_NODE;
 
 public class TektonAction extends StructureTreeAction {
     Logger logger = LoggerFactory.getLogger(TektonAction.class);
@@ -69,12 +70,13 @@ public class TektonAction extends StructureTreeAction {
         return content;
     }
 
-    public void createAndOpenVirtualFile(Project project, String namespace, String name, String content, String kind) {
+    public void createAndOpenVirtualFile(Project project, String namespace, String name, String content, String kind, ParentableNode targetNode) {
         try {
             VirtualFile vf = createTempFile(name, content);
             vf.putUserData(KIND_PLURAL, kind);
             vf.putUserData(PROJECT, project);
             vf.putUserData(NAMESPACE, namespace);
+            vf.putUserData(TARGET_NODE, targetNode);
             File fileToDelete = new File(vf.getPath());
             fileToDelete.deleteOnExit();
             FileEditorManager.getInstance(project).openFile(vf, true);

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/clustertask/CreateClusterTaskAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/clustertask/CreateClusterTaskAction.java
@@ -26,11 +26,12 @@ public class CreateClusterTaskAction extends TektonAction {
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Tkn tkncli) {
-        String namespace = ((ClusterTasksNode)getElement(selected)).getParent().getName();
+        ClusterTasksNode item = getElement(selected);
+        String namespace = item.getParent().getName();
         String content = getSnippet("Tekton: ClusterTask");
 
         if (!Strings.isNullOrEmpty(content)) {
-            createAndOpenVirtualFile(anActionEvent.getProject(), namespace, "newclustertask.yaml", content, KIND_CLUSTERTASKS);
+            createAndOpenVirtualFile(anActionEvent.getProject(), namespace, "newclustertask.yaml", content, KIND_CLUSTERTASKS, item);
         }
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/condition/CreateConditionAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/condition/CreateConditionAction.java
@@ -25,11 +25,12 @@ public class CreateConditionAction extends TektonAction {
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Tkn tkncli) {
-        String namespace = ((ConditionsNode)getElement(selected)).getParent().getName();
+        ConditionsNode item = getElement(selected);
+        String namespace = item.getParent().getName();
         String content = getSnippet("Tekton: Condition");
 
         if (!Strings.isNullOrEmpty(content)) {
-            createAndOpenVirtualFile(anActionEvent.getProject(), namespace, namespace + "-newcondition.yaml", content, KIND_CONDITIONS);
+            createAndOpenVirtualFile(anActionEvent.getProject(), namespace, namespace + "-newcondition.yaml", content, KIND_CONDITIONS, item);
         }
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/pipeline/CreatePipelineAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/pipeline/CreatePipelineAction.java
@@ -26,11 +26,12 @@ public class CreatePipelineAction extends TektonAction {
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Tkn tkncli) {
-        String namespace = ((PipelinesNode)getElement(selected)).getParent().getName();
+        PipelinesNode item = getElement(selected);
+        String namespace = item.getParent().getName();
         String content = getSnippet("Tekton: Pipeline");
 
         if (!Strings.isNullOrEmpty(content)) {
-            createAndOpenVirtualFile(anActionEvent.getProject(), namespace,namespace + "-newpipeline.yaml", content, KIND_PIPELINES);
+            createAndOpenVirtualFile(anActionEvent.getProject(), namespace,namespace + "-newpipeline.yaml", content, KIND_PIPELINES, item);
         }
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/resource/CreateResourceAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/resource/CreateResourceAction.java
@@ -26,11 +26,12 @@ public class CreateResourceAction extends TektonAction {
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Tkn tkncli) {
-        String namespace = ((ResourcesNode)getElement(selected)).getParent().getName();
+        ResourcesNode item = getElement(selected);
+        String namespace = item.getParent().getName();
         String content = getSnippet("Tekton: PipelineResource");
 
         if (!Strings.isNullOrEmpty(content)) {
-            createAndOpenVirtualFile(anActionEvent.getProject(), namespace, namespace + "-newresource.yaml", content, KIND_RESOURCES);
+            createAndOpenVirtualFile(anActionEvent.getProject(), namespace, namespace + "-newresource.yaml", content, KIND_RESOURCES, item);
         }
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/task/CreateTaskAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/task/CreateTaskAction.java
@@ -25,11 +25,12 @@ public class CreateTaskAction extends TektonAction {
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Tkn tkncli) {
-        String namespace = ((TasksNode)getElement(selected)).getParent().getName();
+        TasksNode item = getElement(selected);
+        String namespace = item.getParent().getName();
         String content = getSnippet("Tekton: Task");
 
         if (!Strings.isNullOrEmpty(content)) {
-            createAndOpenVirtualFile(anActionEvent.getProject(), namespace, namespace + "-newtask.yaml", content, KIND_TASKS);
+            createAndOpenVirtualFile(anActionEvent.getProject(), namespace, namespace + "-newtask.yaml", content, KIND_TASKS, item);
         }
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/triggers/CreateClusterTriggerBindingAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/triggers/CreateClusterTriggerBindingAction.java
@@ -25,11 +25,12 @@ public class CreateClusterTriggerBindingAction extends TektonAction {
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Tkn tkncli) {
-        String namespace = ((ClusterTriggerBindingsNode)getElement(selected)).getParent().getName();
+        ClusterTriggerBindingsNode item = getElement(selected);
+        String namespace = item.getParent().getName();
         String content = getSnippet("Tekton: ClusterTriggerBinding");
 
         if (!Strings.isNullOrEmpty(content)) {
-            createAndOpenVirtualFile(anActionEvent.getProject(), namespace, namespace + "-newclustertriggerbinding.yaml", content, KIND_CLUSTERTRIGGERBINDINGS);
+            createAndOpenVirtualFile(anActionEvent.getProject(), namespace, namespace + "-newclustertriggerbinding.yaml", content, KIND_CLUSTERTRIGGERBINDINGS, item);
         }
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/triggers/CreateEventListenerAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/triggers/CreateEventListenerAction.java
@@ -25,11 +25,12 @@ public class CreateEventListenerAction extends TektonAction {
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Tkn tkncli) {
-        String namespace = ((EventListenersNode)getElement(selected)).getParent().getName();
+        EventListenersNode item = getElement(selected);
+        String namespace = item.getParent().getName();
         String content = getSnippet("Tekton: EventListener");
 
         if (!Strings.isNullOrEmpty(content)) {
-            createAndOpenVirtualFile(anActionEvent.getProject(), namespace, namespace + "-neweventlistener.yaml", content, KIND_EVENTLISTENER);
+            createAndOpenVirtualFile(anActionEvent.getProject(), namespace, namespace + "-neweventlistener.yaml", content, KIND_EVENTLISTENER, item);
         }
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/triggers/CreateTriggerBindingAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/triggers/CreateTriggerBindingAction.java
@@ -25,11 +25,12 @@ public class CreateTriggerBindingAction extends TektonAction {
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Tkn tkncli) {
-        String namespace = ((TriggerBindingsNode)getElement(selected)).getParent().getName();
+        TriggerBindingsNode item = getElement(selected);
+        String namespace = item.getParent().getName();
         String content = getSnippet("Tekton: TriggerBinding");
 
         if (!Strings.isNullOrEmpty(content)) {
-            createAndOpenVirtualFile(anActionEvent.getProject(), namespace, namespace + "-newtriggerbinding.yaml", content, KIND_TRIGGERBINDINGS);
+            createAndOpenVirtualFile(anActionEvent.getProject(), namespace, namespace + "-newtriggerbinding.yaml", content, KIND_TRIGGERBINDINGS, item);
         }
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/triggers/CreateTriggerTemplateAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/triggers/CreateTriggerTemplateAction.java
@@ -25,11 +25,12 @@ public class CreateTriggerTemplateAction extends TektonAction {
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Tkn tkncli) {
-        String namespace = ((TriggerTemplatesNode)getElement(selected)).getParent().getName();
+        TriggerTemplatesNode item = getElement(selected);
+        String namespace = item.getParent().getName();
         String content = getSnippet("Tekton: TriggerTemplate");
 
         if (!Strings.isNullOrEmpty(content)) {
-            createAndOpenVirtualFile(anActionEvent.getProject(), namespace, namespace + "-newtriggertemplate.yaml", content, KIND_TRIGGERTEMPLATES);
+            createAndOpenVirtualFile(anActionEvent.getProject(), namespace, namespace + "-newtriggertemplate.yaml", content, KIND_TRIGGERTEMPLATES, item);
         }
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/TreeHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/TreeHelper.java
@@ -15,34 +15,6 @@ import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.treeStructure.Tree;
-import com.intellij.util.ui.tree.TreeUtil;
-import com.redhat.devtools.intellij.common.actions.StructureTreeAction;
-import com.redhat.devtools.intellij.tektoncd.tree.ClusterTasksNode;
-import com.redhat.devtools.intellij.tektoncd.tree.ClusterTriggerBindingsNode;
-import com.redhat.devtools.intellij.tektoncd.tree.ConditionsNode;
-import com.redhat.devtools.intellij.tektoncd.tree.EventListenersNode;
-import com.redhat.devtools.intellij.tektoncd.tree.NamespaceNode;
-import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
-import com.redhat.devtools.intellij.tektoncd.tree.PipelinesNode;
-import com.redhat.devtools.intellij.tektoncd.tree.ResourcesNode;
-import com.redhat.devtools.intellij.tektoncd.tree.TasksNode;
-import com.redhat.devtools.intellij.tektoncd.tree.TektonTreeStructure;
-import com.redhat.devtools.intellij.tektoncd.tree.TriggerBindingsNode;
-import com.redhat.devtools.intellij.tektoncd.tree.TriggerTemplatesNode;
-
-import java.util.Optional;
-import java.util.stream.StreamSupport;
-
-import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_CLUSTERTASKS;
-import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_CLUSTERTRIGGERBINDINGS;
-import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_CONDITIONS;
-import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_EVENTLISTENER;
-import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_PIPELINES;
-import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_RESOURCES;
-import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_TASKS;
-import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_TRIGGERBINDINGS;
-import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_TRIGGERTEMPLATES;
-import static com.redhat.devtools.intellij.tektoncd.Constants.STRUCTURE_PROPERTY;
 
 public class TreeHelper {
 
@@ -50,47 +22,5 @@ public class TreeHelper {
         ToolWindow window = ToolWindowManager.getInstance(project).getToolWindow("Tekton");
         JBScrollPane pane = (JBScrollPane) window.getContentManager().findContent("").getComponent();
         return (Tree) pane.getViewport().getView();
-    }
-
-    /**
-     *
-     * Refresh node with name and kind on tree.
-     * If name is empty refresh first node of that kind
-     *
-     * @param tree tree of node to be refreshed
-     * @param kind kind of node to be refreshed
-     * @param namespace name of node to be refreshed
-     */
-    public static void refreshNode(Tree tree, String kind, String namespace) {
-        if (tree == null) {
-            return;
-        }
-
-
-        Class nodeClass = retrieveNodeClassByKind(kind);
-
-        if (nodeClass == null) return;
-        Optional<Object> element = StreamSupport.stream(TreeUtil.treeTraverser(tree).spliterator(), false)
-                .map(StructureTreeAction::getElement)
-                .filter(el -> el instanceof ParentableNode && ((ParentableNode)el).getParent() instanceof NamespaceNode && ((NamespaceNode)((ParentableNode)el).getParent()).getName().equals(namespace))
-                .filter(el -> nodeClass.isInstance(el)).findFirst();
-        if (element.isPresent()) {
-            ((TektonTreeStructure) tree.getClientProperty(STRUCTURE_PROPERTY)).fireModified(element.get());
-        }
-    }
-
-    public static Class retrieveNodeClassByKind(String kind) {
-        switch(kind) {
-            case KIND_CLUSTERTASKS: return ClusterTasksNode.class;
-            case KIND_PIPELINES: return PipelinesNode.class;
-            case KIND_RESOURCES: return ResourcesNode.class;
-            case KIND_TASKS: return TasksNode.class;
-            case KIND_CONDITIONS: return ConditionsNode.class;
-            case KIND_TRIGGERTEMPLATES: return TriggerTemplatesNode.class;
-            case KIND_TRIGGERBINDINGS: return TriggerBindingsNode.class;
-            case KIND_CLUSTERTRIGGERBINDINGS: return ClusterTriggerBindingsNode.class;
-            case KIND_EVENTLISTENER: return EventListenersNode.class;
-            default: return null;
-        }
     }
 }


### PR DESCRIPTION
it should resolve #102 

@jeffmaury From my tests it looks like there are many threads in queue when creating a new resource. All those threads are related to "find children for X node". From my understanding, when we try to find out which is the node to be refreshed, we go through all the tree and this invokes all these 'find children nodes' and based on the length of the tree it could take more or less time. This is also true as you say it takes only 10 sec for you to load the tree and in my case i have to wait more as in CRC i have lot of projects. Not sure if you know another way to fix this. I'm open to suggestion