### PR TITLE
added watch implementation to update tree automatically (#73)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ intellij {
 }
 
 dependencies {
-    compile 'io.fabric8:openshift-client:4.9.0'
+    compile 'io.fabric8:openshift-client:4.10.2'
     compile 'io.fabric8:tekton-client:4.10.2'
     compile 'com.redhat.devtools.intellij:intellij-common:0.0.1-SNAPSHOT'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ intellij {
 
 dependencies {
     compile 'io.fabric8:openshift-client:4.9.0'
+    compile 'io.fabric8:tekton-client:4.10.2'
     compile 'com.redhat.devtools.intellij:intellij-common:0.0.1-SNAPSHOT'
 }
 

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/WindowToolFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/WindowToolFactory.java
@@ -25,6 +25,7 @@ import com.intellij.ui.tree.StructureTreeModel;
 import com.intellij.ui.treeStructure.Tree;
 import com.redhat.devtools.intellij.common.tree.MutableModelSynchronizer;
 import com.redhat.devtools.intellij.tektoncd.listener.TreeDoubleClickListener;
+import com.redhat.devtools.intellij.tektoncd.listener.TreeExpansionListener;
 import com.redhat.devtools.intellij.tektoncd.tree.TektonTreeStructure;
 import org.jetbrains.annotations.NotNull;
 
@@ -43,9 +44,10 @@ public class WindowToolFactory implements ToolWindowFactory {
             Tree tree = new Tree(new AsyncTreeModel(model, project));
             tree.putClientProperty(Constants.STRUCTURE_PROPERTY, structure);
             tree.setCellRenderer(new NodeRenderer());
+            tree.addTreeWillExpandListener(new TreeExpansionListener());
             PopupHandler.installPopupHandler(tree, "com.redhat.devtools.intellij.tektoncd.tree", ActionPlaces.UNKNOWN);
             toolWindow.getContentManager().addContent(contentFactory.createContent(new JBScrollPane(tree), "", false));
-           new TreeDoubleClickListener(tree);
+            new TreeDoubleClickListener(tree);
         } catch (IllegalAccessException | InvocationTargetException | InstantiationException | NoSuchMethodException e) {
             throw new RuntimeException((e));
         }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/listener/TreeExpansionListener.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/listener/TreeExpansionListener.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.listener;
+
+import com.redhat.devtools.intellij.common.actions.StructureTreeAction;
+import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
+import com.redhat.devtools.intellij.tektoncd.utils.WatchHandler;
+
+import javax.swing.event.TreeExpansionEvent;
+import javax.swing.event.TreeWillExpandListener;
+
+public class TreeExpansionListener implements TreeWillExpandListener {
+    @Override
+    public void treeWillExpand(TreeExpansionEvent treeExpansionEvent) {
+        ParentableNode<? extends ParentableNode<?>> expandingElement = StructureTreeAction.getElement(treeExpansionEvent.getPath().getLastPathComponent());
+        if (WatchHandler.get().canBeWatched(expandingElement)) {
+            WatchHandler.get().setWatch(expandingElement);
+        }
+    }
+
+    @Override
+    public void treeWillCollapse(TreeExpansionEvent treeExpansionEvent) {
+        ParentableNode<? extends ParentableNode<?>> collapsingElement = StructureTreeAction.getElement(treeExpansionEvent.getPath().getLastPathComponent());
+        if (WatchHandler.get().canBeWatched(collapsingElement)) {
+            WatchHandler.get().removeWatch(collapsingElement);
+        }
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tree/TektonRootNode.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tree/TektonRootNode.java
@@ -16,11 +16,14 @@ import com.redhat.devtools.intellij.tektoncd.tkn.TknCliFactory;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.tekton.client.DefaultTektonClient;
+import io.fabric8.tekton.client.TektonClient;
 
 import java.util.concurrent.CompletableFuture;
 
 public class TektonRootNode {
   private KubernetesClient client = loadClient();
+  private TektonClient tektonClient = loadTektonClient();
   private final Project project;
   private Tkn tkn;
 
@@ -32,8 +35,16 @@ public class TektonRootNode {
     return client;
   }
 
+  public TektonClient getTektonClient() {
+    return tektonClient;
+  }
+
   private KubernetesClient loadClient() {
     return new DefaultKubernetesClient(new ConfigBuilder().build());
+  }
+
+  private TektonClient loadTektonClient() {
+    return new DefaultTektonClient(new ConfigBuilder().build());
   }
 
   public CompletableFuture<Tkn> initializeTkn() {

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/WatchHandler.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/WatchHandler.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.utils;
+
+import com.intellij.ui.treeStructure.Tree;
+import com.redhat.devtools.intellij.tektoncd.Constants;
+import com.redhat.devtools.intellij.tektoncd.tree.ClusterTasksNode;
+import com.redhat.devtools.intellij.tektoncd.tree.ClusterTriggerBindingsNode;
+import com.redhat.devtools.intellij.tektoncd.tree.ConditionsNode;
+import com.redhat.devtools.intellij.tektoncd.tree.EventListenersNode;
+import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
+import com.redhat.devtools.intellij.tektoncd.tree.PipelineRunsNode;
+import com.redhat.devtools.intellij.tektoncd.tree.PipelinesNode;
+import com.redhat.devtools.intellij.tektoncd.tree.ResourcesNode;
+import com.redhat.devtools.intellij.tektoncd.tree.TaskRunsNode;
+import com.redhat.devtools.intellij.tektoncd.tree.TasksNode;
+import com.redhat.devtools.intellij.tektoncd.tree.TektonTreeStructure;
+import com.redhat.devtools.intellij.tektoncd.tree.TriggerBindingsNode;
+import com.redhat.devtools.intellij.tektoncd.tree.TriggerTemplatesNode;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.tekton.client.TektonClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class WatchHandler {
+    private Map<String, Watch> watches;
+
+    private static WatchHandler instance;
+
+    private WatchHandler() {
+        watches = new HashMap<>();
+    }
+
+    public static WatchHandler get() {
+        if (instance == null) {
+            instance = new WatchHandler();
+        }
+        return instance;
+    }
+
+    public void setWatch(ParentableNode<? extends ParentableNode<?>> element) {
+        TektonClient client = element.getRoot().getTektonClient();
+
+        String namespace = element.getNamespace();
+        String watchId = getWatchId(element);
+        Watch watch = null;
+        if (element instanceof PipelinesNode) {
+            watch = client.v1beta1().pipelines().inNamespace(namespace).watch(getWatcher(element));
+        } else if (element instanceof PipelineRunsNode) {
+            watch = client.v1beta1().pipelineRuns().inNamespace(namespace).watch(getWatcher(element));
+        } else if (element instanceof ResourcesNode) {
+            watch = client.v1alpha1().pipelineResources().inNamespace(namespace).watch(getWatcher(element));
+        } else if (element instanceof TasksNode) {
+            watch = client.v1beta1().tasks().inNamespace(namespace).watch(getWatcher(element));
+        } else if (element instanceof TaskRunsNode) {
+            watch = client.v1beta1().taskRuns().inNamespace(namespace).watch(getWatcher(element));
+        } else if (element instanceof ClusterTasksNode) {
+            watch = client.v1beta1().clusterTasks().watch(getWatcher(element));
+        } else if (element instanceof ConditionsNode) {
+            watch = client.v1alpha1().conditions().inNamespace(namespace).watch(getWatcher(element));
+        }
+
+        if (watch != null) {
+            watches.put(watchId, watch);
+        }
+    }
+
+    public void removeWatch(ParentableNode<? extends ParentableNode<?>> element) {
+        String watchId =  getWatchId(element);
+        if (watches.containsKey(watchId)) {
+            Watch watch = watches.get(watchId);
+            watch.close();
+        }
+    }
+
+    private String getWatchId(ParentableNode<? extends ParentableNode<?>> element) {
+        return element.getNamespace() + "-" + element.getName();
+    }
+
+    public <T extends HasMetadata> Watcher<T> getWatcher(ParentableNode<? extends ParentableNode<?>> element) {
+        return new Watcher<T>() {
+            @Override
+            public void eventReceived(Action action, T resource) {
+                Tree tree = TreeHelper.getTree(element.getRoot().getProject());
+                TektonTreeStructure treeStructure = (TektonTreeStructure)tree.getClientProperty(Constants.STRUCTURE_PROPERTY);
+                treeStructure.fireModified(element);
+            }
+
+            @Override
+            public void onClose(KubernetesClientException cause) {  }
+        };
+    }
+
+    public boolean canBeWatched(ParentableNode<? extends ParentableNode<?>> element) {
+        return element instanceof PipelinesNode ||
+               element instanceof PipelineRunsNode ||
+               element instanceof ResourcesNode ||
+               element instanceof TasksNode ||
+               element instanceof TaskRunsNode ||
+               element instanceof ClusterTasksNode ||
+               element instanceof ConditionsNode ||
+               element instanceof TriggerTemplatesNode ||
+               element instanceof TriggerBindingsNode ||
+               element instanceof ClusterTriggerBindingsNode ||
+               element instanceof EventListenersNode;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/WatchHandler.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/WatchHandler.java
@@ -13,9 +13,7 @@ package com.redhat.devtools.intellij.tektoncd.utils;
 import com.intellij.ui.treeStructure.Tree;
 import com.redhat.devtools.intellij.tektoncd.Constants;
 import com.redhat.devtools.intellij.tektoncd.tree.ClusterTasksNode;
-import com.redhat.devtools.intellij.tektoncd.tree.ClusterTriggerBindingsNode;
 import com.redhat.devtools.intellij.tektoncd.tree.ConditionsNode;
-import com.redhat.devtools.intellij.tektoncd.tree.EventListenersNode;
 import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
 import com.redhat.devtools.intellij.tektoncd.tree.PipelineRunsNode;
 import com.redhat.devtools.intellij.tektoncd.tree.PipelinesNode;
@@ -23,8 +21,6 @@ import com.redhat.devtools.intellij.tektoncd.tree.ResourcesNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TaskRunsNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TasksNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TektonTreeStructure;
-import com.redhat.devtools.intellij.tektoncd.tree.TriggerBindingsNode;
-import com.redhat.devtools.intellij.tektoncd.tree.TriggerTemplatesNode;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
@@ -110,10 +106,6 @@ public class WatchHandler {
                element instanceof TasksNode ||
                element instanceof TaskRunsNode ||
                element instanceof ClusterTasksNode ||
-               element instanceof ConditionsNode ||
-               element instanceof TriggerTemplatesNode ||
-               element instanceof TriggerBindingsNode ||
-               element instanceof ClusterTriggerBindingsNode ||
-               element instanceof EventListenersNode;
+               element instanceof ConditionsNode;
     }
 }


### PR DESCRIPTION
it resolves #73 

I had to use the latest version of fabric8 tekton as the previous ones had some issues with betav1 resources. Currently it doesn't support triggers.

I tried this patch by launching pipelines, deleting resources externally from ide and the tree refreshes quite good. Let me know what you think.