### PR TITLE
Fixed issue with cache when saving file (#136)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/VirtualFileHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/VirtualFileHelper.java
@@ -43,8 +43,6 @@ public class VirtualFileHelper {
             vf.putUserData(PROJECT, project);
             vf.putUserData(NAMESPACE, namespace);
             vf.putUserData(TARGET_NODE, targetNode);
-            File fileToDelete = new File(vf.getPath());
-            fileToDelete.deleteOnExit();
             FileEditorManager.getInstance(project).openFile(vf, true);
         } catch (IOException e) {
             logger.warn(e.getLocalizedMessage(), e);
@@ -53,7 +51,12 @@ public class VirtualFileHelper {
 
     private static VirtualFile createTempFile(String name, String content) throws IOException {
         File file = new File(System.getProperty("java.io.tmpdir"), name);
+        if (file.exists()){
+            file.delete();
+            LocalFileSystem.getInstance().refreshIoFiles(Arrays.asList(file));
+        }
         FileUtils.write(file, content, StandardCharsets.UTF_8);
+        file.deleteOnExit();
         return LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file);
     }
 }


### PR DESCRIPTION
Long story short.

Based on https://www.jetbrains.org/intellij/sdk/docs/basics/virtual_file_system.html, the virtual file system encapsulates most of the activity related to files. One of the main goal is "Tracking file modifications and providing both old and new versions of the file content when a modification is detected" which is what we have in the current implementation.

Because the vfs manages a persistent snapshot of the user's hard disk what we were missing was to delete the file from the tmp folder and clean (refresh) the vfs so to delete the cached version.

