### PR TITLE
Improve/Extend watch feature

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/WindowToolFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/WindowToolFactory.java
@@ -13,6 +13,8 @@ package com.redhat.devtools.intellij.tektoncd;
 import com.intellij.ide.util.treeView.AbstractTreeStructure;
 import com.intellij.ide.util.treeView.NodeRenderer;
 import com.intellij.openapi.Disposable;
+import com.intellij.openapi.actionSystem.ActionGroup;
+import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.ActionPlaces;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
@@ -26,6 +28,7 @@ import com.intellij.ui.treeStructure.Tree;
 import com.redhat.devtools.intellij.common.tree.MutableModelSynchronizer;
 import com.redhat.devtools.intellij.tektoncd.listener.TreeDoubleClickListener;
 import com.redhat.devtools.intellij.tektoncd.listener.TreeExpansionListener;
+import com.redhat.devtools.intellij.tektoncd.listener.TreePopupMenuListener;
 import com.redhat.devtools.intellij.tektoncd.tree.TektonTreeStructure;
 import org.jetbrains.annotations.NotNull;
 
@@ -45,7 +48,10 @@ public class WindowToolFactory implements ToolWindowFactory {
             tree.putClientProperty(Constants.STRUCTURE_PROPERTY, structure);
             tree.setCellRenderer(new NodeRenderer());
             tree.addTreeWillExpandListener(new TreeExpansionListener());
-            PopupHandler.installPopupHandler(tree, "com.redhat.devtools.intellij.tektoncd.tree", ActionPlaces.UNKNOWN);
+            //PopupHandler.installPopupHandler(tree, "com.redhat.devtools.intellij.tektoncd.tree", ActionPlaces.UNKNOWN);
+            ActionManager actionManager = ActionManager.getInstance();
+            ActionGroup group = (ActionGroup)actionManager.getAction("com.redhat.devtools.intellij.tektoncd.tree");
+            PopupHandler.installPopupHandler(tree, group, ActionPlaces.UNKNOWN, actionManager, new TreePopupMenuListener());
             toolWindow.getContentManager().addContent(contentFactory.createContent(new JBScrollPane(tree), "", false));
             new TreeDoubleClickListener(tree);
         } catch (IllegalAccessException | InvocationTargetException | InstantiationException | NoSuchMethodException e) {

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/WindowToolFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/WindowToolFactory.java
@@ -48,7 +48,6 @@ public class WindowToolFactory implements ToolWindowFactory {
             tree.putClientProperty(Constants.STRUCTURE_PROPERTY, structure);
             tree.setCellRenderer(new NodeRenderer());
             tree.addTreeWillExpandListener(new TreeExpansionListener());
-            //PopupHandler.installPopupHandler(tree, "com.redhat.devtools.intellij.tektoncd.tree", ActionPlaces.UNKNOWN);
             ActionManager actionManager = ActionManager.getInstance();
             ActionGroup group = (ActionGroup)actionManager.getAction("com.redhat.devtools.intellij.tektoncd.tree");
             PopupHandler.installPopupHandler(tree, group, ActionPlaces.UNKNOWN, actionManager, new TreePopupMenuListener());

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/listener/TreePopupMenuListener.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/listener/TreePopupMenuListener.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.listener;
+
+import com.redhat.devtools.intellij.tektoncd.utils.RefreshQueue;
+
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
+
+public class TreePopupMenuListener implements PopupMenuListener {
+    private static RefreshQueue queue = RefreshQueue.get();
+    private static boolean isMenuVisible = false;
+
+    public static boolean isTreeMenuVisible() {
+        return isMenuVisible;
+    }
+
+    @Override
+    public void popupMenuWillBecomeVisible(PopupMenuEvent popupMenuEvent) {
+        isMenuVisible = true;
+    }
+
+    @Override
+    public void popupMenuWillBecomeInvisible(PopupMenuEvent popupMenuEvent) {
+        isMenuVisible = false;
+        queue.refresh();
+    }
+
+    @Override
+    public void popupMenuCanceled(PopupMenuEvent popupMenuEvent) {
+        isMenuVisible = false;
+        queue.refresh();
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/listener/TreePopupMenuListener.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/listener/TreePopupMenuListener.java
@@ -16,7 +16,7 @@ import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
 
 public class TreePopupMenuListener implements PopupMenuListener {
-    private static RefreshQueue queue = RefreshQueue.get();
+    private static final RefreshQueue queue = RefreshQueue.get();
     private static boolean isMenuVisible = false;
 
     public static boolean isTreeMenuVisible() {
@@ -31,12 +31,12 @@ public class TreePopupMenuListener implements PopupMenuListener {
     @Override
     public void popupMenuWillBecomeInvisible(PopupMenuEvent popupMenuEvent) {
         isMenuVisible = false;
-        queue.refresh();
+        queue.update();
     }
 
     @Override
     public void popupMenuCanceled(PopupMenuEvent popupMenuEvent) {
         isMenuVisible = false;
-        queue.refresh();
+        queue.update();
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/RunDeserializer.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/RunDeserializer.java
@@ -55,7 +55,7 @@ public class RunDeserializer extends StdNodeBasedDeserializer<Run> {
             JsonNode conditionChecks = item.get("conditionChecks");
             JsonNode conditions = item.get("status").get("conditions");
             String failedReason = "";
-            if (conditions.isArray() && conditions.size() > 0) {
+            if (conditions != null && conditions.isArray() && conditions.size() > 0) {
                 failedReason = conditions.get(0).get("reason").asText("");
             }
 

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/Tkn.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/Tkn.java
@@ -11,10 +11,14 @@
 package com.redhat.devtools.intellij.tektoncd.tkn;
 
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Workspace;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
-import io.fabric8.tekton.client.TektonClient;
 import io.fabric8.tekton.pipeline.v1alpha1.Condition;
-
+import io.fabric8.tekton.pipeline.v1beta1.ClusterTask;
+import io.fabric8.tekton.pipeline.v1beta1.Pipeline;
+import io.fabric8.tekton.pipeline.v1beta1.Task;
+import io.fabric8.tekton.resource.v1alpha1.PipelineResource;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
@@ -480,6 +484,75 @@ public interface Tkn {
      * @param pipelineRun name of the PipelineRun
      */
     String getPipelineRunYAML(String namespace, String pipelineRun) throws IOException;
+
+    /**
+     * Set a watch on Pipeline resources
+     *
+     * @param namespace the namespace to use
+     * @param watcher the watcher to call when a new event is received
+     * @return the watch object
+     * @throws IOException if communication errored
+     */
+    Watch watchPipelines(String namespace, Watcher<Pipeline> watcher) throws IOException;
+
+    /**
+     * Set a watch on PipelineRun resources
+     *
+     * @param namespace the namespace to use
+     * @param watcher the watcher to call when a new event is received
+     * @return the watch object
+     * @throws IOException if communication errored
+     */
+    Watch watchPipelineRuns(String namespace, Watcher<io.fabric8.tekton.pipeline.v1beta1.PipelineRun> watcher) throws IOException;
+
+    /**
+     * Set a watch on Task resources
+     *
+     * @param namespace the namespace to use
+     * @param watcher the watcher to call when a new event is received
+     * @return the watch object
+     * @throws IOException if communication errored
+     */
+    Watch watchTasks(String namespace, Watcher<Task> watcher) throws IOException;
+
+    /**
+     * Set a watch on TaskRun resources
+     *
+     * @param namespace the namespace to use
+     * @param watcher the watcher to call when a new event is received
+     * @return the watch object
+     * @throws IOException if communication errored
+     */
+    Watch watchTaskRuns(String namespace, Watcher<io.fabric8.tekton.pipeline.v1beta1.TaskRun> watcher) throws IOException;
+
+    /**
+     * Set a watch on PipelineResource resources
+     *
+     * @param namespace the namespace to use
+     * @param watcher the watcher to call when a new event is received
+     * @return the watch object
+     * @throws IOException if communication errored
+     */
+    Watch watchPipelineResources(String namespace, Watcher<PipelineResource> watcher) throws IOException;
+
+    /**
+     * Set a watch on ClusterTask resources
+     *
+     * @param watcher the watcher to call when a new event is received
+     * @return the watch object
+     * @throws IOException if communication errored
+     */
+    Watch watchClusterTasks(Watcher<ClusterTask> watcher) throws IOException;
+
+    /**
+     * Set a watch on Condition resources
+     *
+     * @param namespace the namespace to use
+     * @param watcher the watcher to call when a new event is received
+     * @return the watch object
+     * @throws IOException if communication errored
+     */
+    Watch watchConditions(String namespace, Watcher<io.fabric8.tekton.pipeline.v1alpha1.Condition> watcher) throws IOException;
 
     public URL getMasterUrl();
 

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCli.java
@@ -22,13 +22,19 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.tekton.client.TektonClient;
+import io.fabric8.tekton.pipeline.v1beta1.ClusterTask;
 import io.fabric8.tekton.pipeline.v1beta1.ClusterTaskList;
+import io.fabric8.tekton.pipeline.v1beta1.Pipeline;
 import io.fabric8.tekton.pipeline.v1beta1.PipelineList;
+import io.fabric8.tekton.pipeline.v1beta1.Task;
 import io.fabric8.tekton.pipeline.v1beta1.TaskList;
 import io.fabric8.tekton.pipeline.v1alpha1.Condition;
+import io.fabric8.tekton.resource.v1alpha1.PipelineResource;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -442,6 +448,69 @@ public class TknCli implements Tkn {
     @Override
     public String getPipelineRunYAML(String namespace, String pipelineRun) throws IOException {
         return ExecHelper.execute(command, envVars, "pipelinerun", "describe", pipelineRun, "-n", namespace, "-o", "yaml");
+    }
+
+    @Override
+    public Watch watchPipelines(String namespace, Watcher<Pipeline> watcher) throws IOException {
+        try {
+            return client.adapt(TektonClient.class).v1beta1().pipelines().inNamespace(namespace).watch(watcher);
+        } catch (KubernetesClientException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public Watch watchPipelineRuns(String namespace, Watcher<io.fabric8.tekton.pipeline.v1beta1.PipelineRun> watcher) throws IOException {
+        try {
+            return client.adapt(TektonClient.class).v1beta1().pipelineRuns().inNamespace(namespace).watch(watcher);
+        } catch (KubernetesClientException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public Watch watchTasks(String namespace, Watcher<Task> watcher) throws IOException {
+        try {
+            return client.adapt(TektonClient.class).v1beta1().tasks().inNamespace(namespace).watch(watcher);
+        } catch (KubernetesClientException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public Watch watchTaskRuns(String namespace, Watcher<io.fabric8.tekton.pipeline.v1beta1.TaskRun> watcher) throws IOException {
+        try {
+            return client.adapt(TektonClient.class).v1beta1().taskRuns().inNamespace(namespace).watch(watcher);
+        } catch (KubernetesClientException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public Watch watchPipelineResources(String namespace, Watcher<PipelineResource> watcher) throws IOException {
+        try {
+            return client.adapt(TektonClient.class).v1alpha1().pipelineResources().inNamespace(namespace).watch(watcher);
+        } catch (KubernetesClientException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public Watch watchClusterTasks(Watcher<ClusterTask> watcher) throws IOException {
+        try {
+            return client.adapt(TektonClient.class).v1beta1().clusterTasks().watch(watcher);
+        } catch (KubernetesClientException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public Watch watchConditions(String namespace, Watcher<io.fabric8.tekton.pipeline.v1alpha1.Condition> watcher) throws IOException {
+        try {
+            return client.adapt(TektonClient.class).v1alpha1().conditions().inNamespace(namespace).watch(watcher);
+        } catch (KubernetesClientException e) {
+            throw new IOException(e);
+        }
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/RefreshQueue.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/RefreshQueue.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.utils;
+
+import com.intellij.ui.treeStructure.Tree;
+import com.redhat.devtools.intellij.tektoncd.Constants;
+import com.redhat.devtools.intellij.tektoncd.listener.TreePopupMenuListener;
+import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
+import com.redhat.devtools.intellij.tektoncd.tree.TektonTreeStructure;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Timer;
+import java.util.TimerTask;
+
+public class RefreshQueue {
+    private static RefreshQueue instance;
+    private Queue<ParentableNode> queue;
+    private Timer timer;
+
+    private RefreshQueue() {
+        queue = new LinkedList<>();
+    }
+
+    public static RefreshQueue get() {
+        if (instance == null) {
+            instance = new RefreshQueue();
+        }
+        return instance;
+    }
+
+    public void addAll(List<ParentableNode> nodes) {
+        if (timer != null) {
+            timer.cancel();
+        }
+
+        for (ParentableNode node: nodes) {
+            if (!queue.stream().anyMatch(element -> element.getName().equals(node.getName()) && element.getParent().equals(node.getParent()))) {
+                queue.add(node);
+            }
+        }
+
+        timer = new Timer();
+        timer.schedule(
+                new TimerTask() {
+                    @Override
+                    public void run() {
+                        if (!TreePopupMenuListener.isTreeMenuVisible()) {
+                            refresh();
+                        }
+                    }
+                },
+                500
+        );
+    }
+
+    public void refresh() {
+        while (!queue.isEmpty()) {
+            ParentableNode element = queue.poll();
+            if (element == null) return;
+            Tree tree = TreeHelper.getTree(element.getRoot().getProject());
+            TektonTreeStructure treeStructure = (TektonTreeStructure)tree.getClientProperty(Constants.STRUCTURE_PROPERTY);
+            treeStructure.fireModified(element);
+        }
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/WatchHandler.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/WatchHandler.java
@@ -26,11 +26,14 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.tekton.client.TektonClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class WatchHandler {
+    private static final Logger logger = LoggerFactory.getLogger(WatchHandler.class);
     private Map<String, Watch> watches;
 
     private static WatchHandler instance;
@@ -52,20 +55,25 @@ public class WatchHandler {
         String namespace = element.getNamespace();
         String watchId = getWatchId(element);
         Watch watch = null;
-        if (element instanceof PipelinesNode) {
-            watch = client.v1beta1().pipelines().inNamespace(namespace).watch(getWatcher(element));
-        } else if (element instanceof PipelineRunsNode) {
-            watch = client.v1beta1().pipelineRuns().inNamespace(namespace).watch(getWatcher(element));
-        } else if (element instanceof ResourcesNode) {
-            watch = client.v1alpha1().pipelineResources().inNamespace(namespace).watch(getWatcher(element));
-        } else if (element instanceof TasksNode) {
-            watch = client.v1beta1().tasks().inNamespace(namespace).watch(getWatcher(element));
-        } else if (element instanceof TaskRunsNode) {
-            watch = client.v1beta1().taskRuns().inNamespace(namespace).watch(getWatcher(element));
-        } else if (element instanceof ClusterTasksNode) {
-            watch = client.v1beta1().clusterTasks().watch(getWatcher(element));
-        } else if (element instanceof ConditionsNode) {
-            watch = client.v1alpha1().conditions().inNamespace(namespace).watch(getWatcher(element));
+
+        try {
+            if (element instanceof PipelinesNode) {
+                watch = client.v1beta1().pipelines().inNamespace(namespace).watch(getWatcher(element));
+            } else if (element instanceof PipelineRunsNode) {
+                watch = client.v1beta1().pipelineRuns().inNamespace(namespace).watch(getWatcher(element));
+            } else if (element instanceof ResourcesNode) {
+                watch = client.v1alpha1().pipelineResources().inNamespace(namespace).watch(getWatcher(element));
+            } else if (element instanceof TasksNode) {
+                watch = client.v1beta1().tasks().inNamespace(namespace).watch(getWatcher(element));
+            } else if (element instanceof TaskRunsNode) {
+                watch = client.v1beta1().taskRuns().inNamespace(namespace).watch(getWatcher(element));
+            } else if (element instanceof ClusterTasksNode) {
+                watch = client.v1beta1().clusterTasks().watch(getWatcher(element));
+            } else if (element instanceof ConditionsNode) {
+                watch = client.v1alpha1().conditions().inNamespace(namespace).watch(getWatcher(element));
+            }
+        } catch (KubernetesClientException e) {
+            logger.warn("Error: " + e.getLocalizedMessage());
         }
 
         if (watch != null) {


### PR DESCRIPTION
it fixes #127 

Now the watch feature also works with internal nodes such as pipelineruns below a pipeline node and taskruns below task/pipelinerun nodes.

As agreed the refresh is now frozen if the context menu is opened and the tree is updated again when the menu get closed.