### PR TITLE
add code completion for conditions (#151)

### DIFF
--- a/.github/workflows/IJ.yml
+++ b/.github/workflows/IJ.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        IJ: [IC-2018.3, IC-2019.1, IC-2019.2, IC-2019.3, IC-2020.1]
+        IJ: [IC-2019.2, IC-2019.3, IC-2020.1]
 
     steps:
     - uses: actions/checkout@v2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-ideaVersion = IC-2018.3
+ideaVersion = IC-2019.2
 projectVersion=0.0.2
 jetBrainsToken=invalid
 jetBrainsChannel=stable

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/BaseAutoInsertHandler.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/BaseAutoInsertHandler.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.completion;
+
+import com.intellij.openapi.editor.Document;
+
+import java.util.Collections;
+
+public class BaseAutoInsertHandler {
+    protected int getParentIndentation(Document document, int offset) {
+        int positionNewLine = document.getText().substring(0, offset).lastIndexOf("\n");
+        int nSpaces = document.getText().indexOf("- conditionRef", positionNewLine);
+        return (nSpaces + 1) - (positionNewLine + 2);
+    }
+
+    protected String getIndentationAsText(int indentationParent, int indentSize, int level) {
+        return String.join("", Collections.nCopies(indentationParent + (indentSize * level), " "));
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/ConditionAutoInsertHandler.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/ConditionAutoInsertHandler.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.completion;
+
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.completion.InsertionContext;
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.openapi.editor.Document;
+import io.fabric8.tekton.pipeline.v1alpha1.Condition;
+import io.fabric8.tekton.resource.v1alpha1.ResourceDeclaration;
+import io.fabric8.tekton.v1alpha1.internal.pipeline.pkg.apis.pipeline.v1alpha2.ParamSpec;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+
+public class ConditionAutoInsertHandler implements InsertHandler<LookupElement> {
+
+    @Override
+    public void handleInsert(@NotNull InsertionContext context, @NotNull LookupElement item) {
+        Document document = context.getEditor().getDocument();
+        Condition condition = (Condition) item.getObject();
+        int startOffset = context.getStartOffset();
+        int tailOffset = context.getTailOffset();
+        int indentationSize = context.getCodeStyleSettings().getIndentOptions().INDENT_SIZE;
+        int indentationParent = getParentIndentation(document, startOffset);
+
+        String completionText = condition.getMetadata().getName() + "\n";
+        if (condition.getSpec().getParams() != null && condition.getSpec().getParams().size() > 0) {
+            completionText += getIndentationAsText(indentationParent, indentationSize, 1) + "params:\n";
+            for (ParamSpec param: condition.getSpec().getParams()) {
+                completionText += getIndentationAsText(indentationParent, indentationSize, 1) + "- name: " + param.getName() + "\n";
+                completionText += getIndentationAsText(indentationParent, indentationSize, 2) + "value: \n";
+            }
+        }
+        if (condition.getSpec().getResources() != null && condition.getSpec().getResources().size() > 0) {
+            completionText += getIndentationAsText(indentationParent, indentationSize, 1) + "resources:\n";
+            for (ResourceDeclaration resource: condition.getSpec().getResources()) {
+                completionText += getIndentationAsText(indentationParent, indentationSize, 1) + "- name: " + resource.getName() + "\n";
+                completionText += getIndentationAsText(indentationParent, indentationSize, 2) + "resource: \n";
+            }
+        }
+        document.replaceString(startOffset, tailOffset, completionText);
+    }
+
+    private int getParentIndentation(Document document, int offset) {
+        int positionNewLine = document.getText().substring(0, offset).lastIndexOf("\n");
+        int nSpaces = document.getText().indexOf("- conditionRef", positionNewLine);
+        return (nSpaces + 1) - (positionNewLine + 2);
+    }
+
+    private String getIndentationAsText(int indentationParent, int indentSize, int level) {
+        return String.join("", Collections.nCopies(indentationParent + (indentSize * level), " "));
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/ConditionAutoInsertHandler.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/ConditionAutoInsertHandler.java
@@ -19,9 +19,7 @@ import io.fabric8.tekton.resource.v1alpha1.ResourceDeclaration;
 import io.fabric8.tekton.v1alpha1.internal.pipeline.pkg.apis.pipeline.v1alpha2.ParamSpec;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collections;
-
-public class ConditionAutoInsertHandler implements InsertHandler<LookupElement> {
+public class ConditionAutoInsertHandler extends BaseAutoInsertHandler implements InsertHandler<LookupElement> {
 
     @Override
     public void handleInsert(@NotNull InsertionContext context, @NotNull LookupElement item) {
@@ -48,15 +46,5 @@ public class ConditionAutoInsertHandler implements InsertHandler<LookupElement> 
             }
         }
         document.replaceString(startOffset, tailOffset, completionText);
-    }
-
-    private int getParentIndentation(Document document, int offset) {
-        int positionNewLine = document.getText().substring(0, offset).lastIndexOf("\n");
-        int nSpaces = document.getText().indexOf("- conditionRef", positionNewLine);
-        return (nSpaces + 1) - (positionNewLine + 2);
-    }
-
-    private String getIndentationAsText(int indentationParent, int indentSize, int level) {
-        return String.join("", Collections.nCopies(indentationParent + (indentSize * level), " "));
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/ConditionCompletionProvider.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/ConditionCompletionProvider.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.completion;
+
+import com.intellij.codeInsight.completion.CompletionParameters;
+import com.intellij.codeInsight.completion.CompletionProvider;
+import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.ProcessingContext;
+import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
+import com.redhat.devtools.intellij.tektoncd.utils.TreeHelper;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.redhat.devtools.intellij.tektoncd.Constants.NAMESPACE;
+
+public class ConditionCompletionProvider extends CompletionProvider<CompletionParameters> {
+    Logger logger = LoggerFactory.getLogger(ConditionCompletionProvider.class);
+
+    @Override
+    protected void addCompletions(@NotNull CompletionParameters parameters, @NotNull ProcessingContext context, @NotNull CompletionResultSet result) {
+        String ns = parameters.getOriginalFile().getVirtualFile().getUserData(NAMESPACE);
+        result.addAllElements(getConditionsLookups(parameters.getEditor().getProject(), ns));
+    }
+
+    private List<LookupElementBuilder> getConditionsLookups(Project project, String namespace) {
+        Tkn tkn = TreeHelper.getTkn(project);
+        List<LookupElementBuilder> lookups = Collections.emptyList();
+        try {
+            lookups = tkn.getConditions(namespace)
+                            .stream()
+                            .map(condition -> LookupElementBuilder.create(condition)
+                                                                    .withPresentableText(condition.getMetadata().getName())
+                                                                    .withLookupString(condition.getMetadata().getName())
+                                                                    .withInsertHandler(new ConditionAutoInsertHandler()))
+                            .collect(Collectors.toList());
+        } catch (IOException e) {
+            logger.warn("Error: " + e.getLocalizedMessage());
+        }
+        return lookups;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/DictionaryContributor.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/DictionaryContributor.java
@@ -20,6 +20,9 @@ public class DictionaryContributor extends CompletionContributor {
     public DictionaryContributor() {
         // completions for plain text yaml files
         extend(CompletionType.BASIC,
+                YamlElementPatternHelper.getSingleLineScalarKey("conditionRef"),
+                new ConditionCompletionProvider());
+        extend(CompletionType.BASIC,
                 PlatformPatterns.psiElement(PlainTextTokenTypes.PLAIN_TEXT),
                 new DictionaryCompletionProvider());
         extend(CompletionType.BASIC,

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/DictionaryContributor.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/DictionaryContributor.java
@@ -18,10 +18,11 @@ import org.jetbrains.yaml.YAMLLanguage;
 
 public class DictionaryContributor extends CompletionContributor {
     public DictionaryContributor() {
-        // completions for plain text yaml files
+        // conditions
         extend(CompletionType.BASIC,
                 YamlElementPatternHelper.getSingleLineScalarKey("conditionRef"),
                 new ConditionCompletionProvider());
+        // general tekton snippets
         extend(CompletionType.BASIC,
                 PlatformPatterns.psiElement(PlainTextTokenTypes.PLAIN_TEXT),
                 new DictionaryCompletionProvider());

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/YamlElementPatternHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/YamlElementPatternHelper.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.completion;
+
+import com.intellij.patterns.ElementPattern;
+import com.intellij.patterns.PlatformPatterns;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.yaml.YAMLLanguage;
+import org.jetbrains.yaml.YAMLTokenTypes;
+import org.jetbrains.yaml.psi.YAMLKeyValue;
+import org.jetbrains.yaml.psi.YAMLScalar;
+
+public class YamlElementPatternHelper {
+    public static ElementPattern<PsiElement> getSingleLineScalarKey(String... keyName) {
+        // it finds key: "value" fields
+        return PlatformPatterns
+                .psiElement(YAMLTokenTypes.TEXT)
+                .withParent(
+                        PlatformPatterns
+                             .psiElement(YAMLScalar.class)
+                             .withParent(
+                                     PlatformPatterns
+                                             .psiElement(YAMLKeyValue.class)
+                                             .withName(
+                                                     PlatformPatterns.string().oneOf(keyName)
+                                             )
+                             )
+                )
+                .withLanguage(YAMLLanguage.INSTANCE);
+
+    }
+
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/Tkn.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/Tkn.java
@@ -14,6 +14,7 @@ import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Workspace;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.tekton.client.TektonClient;
+import io.fabric8.tekton.pipeline.v1alpha1.Condition;
 
 import java.io.IOException;
 import java.util.List;

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCli.java
@@ -25,6 +25,7 @@ import io.fabric8.tekton.client.TektonClient;
 import io.fabric8.tekton.pipeline.v1beta1.ClusterTaskList;
 import io.fabric8.tekton.pipeline.v1beta1.PipelineList;
 import io.fabric8.tekton.pipeline.v1beta1.TaskList;
+import io.fabric8.tekton.pipeline.v1alpha1.Condition;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tree/ConditionNode.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tree/ConditionNode.java
@@ -10,12 +10,12 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.tektoncd.tree;
 
-import com.redhat.devtools.intellij.tektoncd.tkn.Condition;
+import io.fabric8.tekton.pipeline.v1alpha1.Condition;
 
 public class ConditionNode extends ParentableNode<ConditionsNode> {
     private final Condition condition;
     public ConditionNode(TektonRootNode root, ConditionsNode parent, Condition condition) {
-        super(root, parent, condition.getName());
+        super(root, parent, condition.getMetadata().getName());
         this.condition = condition;
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/TreeHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/TreeHelper.java
@@ -19,6 +19,7 @@ import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.treeStructure.Tree;
 import com.redhat.devtools.intellij.common.actions.StructureTreeAction;
 import com.redhat.devtools.intellij.common.utils.UIHelper;
+import com.redhat.devtools.intellij.tektoncd.Constants;
 import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
 import com.redhat.devtools.intellij.tektoncd.tree.ClusterTaskNode;
 import com.redhat.devtools.intellij.tektoncd.tree.ClusterTriggerBindingNode;
@@ -30,6 +31,8 @@ import com.redhat.devtools.intellij.tektoncd.tree.PipelineRunNode;
 import com.redhat.devtools.intellij.tektoncd.tree.ResourceNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TaskNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TaskRunNode;
+import com.redhat.devtools.intellij.tektoncd.tree.TektonRootNode;
+import com.redhat.devtools.intellij.tektoncd.tree.TektonTreeStructure;
 import com.redhat.devtools.intellij.tektoncd.tree.TriggerBindingNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TriggerTemplateNode;
 
@@ -59,6 +62,16 @@ public class TreeHelper {
         ToolWindow window = ToolWindowManager.getInstance(project).getToolWindow("Tekton");
         JBScrollPane pane = (JBScrollPane) window.getContentManager().findContent("").getComponent();
         return (Tree) pane.getViewport().getView();
+    }
+
+    public static Tkn getTkn(Project project) {
+        try {
+            TektonTreeStructure treeStructure = (TektonTreeStructure) getTree(project).getClientProperty(Constants.STRUCTURE_PROPERTY);
+            TektonRootNode root = (TektonRootNode) treeStructure.getRootElement();
+            return root.getTkn();
+        } catch(Exception ex) {
+            return null;
+        }
     }
 
     /**

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -32,7 +32,7 @@
 
 
   <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-  <idea-version since-build="183.4284.148"/>
+  <idea-version since-build="192"/>
 
   <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
        on how to target different products -->
@@ -45,7 +45,6 @@
     <!-- Add your extensions here -->
     <fileDocumentSynchronizationVetoer implementation="com.redhat.devtools.intellij.tektoncd.listener.SaveInEditorListener" order="first" />
     <completion.contributor language="any" implementationClass="com.redhat.devtools.intellij.tektoncd.completion.DictionaryContributor"/>
-    <fileDocumentSynchronizationVetoer implementation="com.redhat.devtools.intellij.tektoncd.listener.SaveInEditorListener" order="first"/>
     <toolWindow id="Tekton" anchor="left" factoryClass="com.redhat.devtools.intellij.tektoncd.WindowToolFactory" icon="/images/cluster.png"/>
   </extensions>
   <actions>


### PR DESCRIPTION
it fixes #151 

The result of the PR is that the code completion menu shows this when called after a `conditionRef`
![image](https://user-images.githubusercontent.com/49404737/87795435-522b6e80-c848-11ea-8ff8-ad0bf680de82.png)

The first three options are actual conditions that exist in the cluster.
The other are the classic snippets we had before and are shown everywhere. I was tempted to remove them as we have schemas now, we should discuss about their life :laughing: 

This is the result by selecting one condition
![image](https://user-images.githubusercontent.com/49404737/87795863-ec8bb200-c848-11ea-83aa-4f360ad87e11.png)

It inserts all params/resources required by the condition so the user only needs to add their values.
