### PR TITLE
Fix issue when config change during runtime

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCliFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCliFactory.java
@@ -12,7 +12,6 @@ package com.redhat.devtools.intellij.tektoncd.tkn;
 
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.intellij.common.utils.DownloadHelper;
-
 import java.util.concurrent.CompletableFuture;
 
 public class TknCliFactory {
@@ -32,8 +31,12 @@ public class TknCliFactory {
 
     public CompletableFuture<Tkn> getTkn(Project project) {
         if (future == null) {
-            future = DownloadHelper.getInstance().downloadIfRequiredAsync("tkn", TknCliFactory.class.getResource("/tkn.json")).thenApply(command -> new TknCli(project, command));
+            setTkn(project);
         }
         return future;
+    }
+
+    public void setTkn(Project project) {
+        future = DownloadHelper.getInstance().downloadIfRequiredAsync("tkn", TknCliFactory.class.getResource("/tkn.json")).thenApply(command -> new TknCli(project, command));
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCliFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCliFactory.java
@@ -31,12 +31,12 @@ public class TknCliFactory {
 
     public CompletableFuture<Tkn> getTkn(Project project) {
         if (future == null) {
-            setTkn(project);
+            future = DownloadHelper.getInstance().downloadIfRequiredAsync("tkn", TknCliFactory.class.getResource("/tkn.json")).thenApply(command -> new TknCli(project, command));
         }
         return future;
     }
 
-    public void setTkn(Project project) {
-        future = DownloadHelper.getInstance().downloadIfRequiredAsync("tkn", TknCliFactory.class.getResource("/tkn.json")).thenApply(command -> new TknCli(project, command));
+    public void resetTkn() {
+        future = null;
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tree/TektonRootNode.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tree/TektonRootNode.java
@@ -25,6 +25,7 @@ public class TektonRootNode {
   }
 
   public CompletableFuture<Tkn> initializeTkn() {
+    TknCliFactory.getInstance().setTkn(project);
     return TknCliFactory.getInstance().getTkn(project).whenComplete((tkn, err) -> this.tkn = tkn);
   }
 

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tree/TektonRootNode.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tree/TektonRootNode.java
@@ -25,7 +25,6 @@ public class TektonRootNode {
   }
 
   public CompletableFuture<Tkn> initializeTkn() {
-    TknCliFactory.getInstance().setTkn(project);
     return TknCliFactory.getInstance().getTkn(project).whenComplete((tkn, err) -> this.tkn = tkn);
   }
 
@@ -34,7 +33,8 @@ public class TektonRootNode {
   }
 
   public void load() {
-      initializeTkn();
+    TknCliFactory.getInstance().resetTkn();
+    initializeTkn();
   }
 
   public Project getProject() {

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tree/TektonTreeStructure.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tree/TektonTreeStructure.java
@@ -470,7 +470,7 @@ public class TektonTreeStructure extends AbstractTreeStructure implements Mutabl
 
     private boolean hasContextChanged(Config newConfig, Config currentConfig) {
         Context currentContext = KubeConfigUtils.getCurrentContext(currentConfig);
-        Context newContext = KubeConfigUtils.getCurrentContext(currentConfig);
+        Context newContext = KubeConfigUtils.getCurrentContext(newConfig);
         return hasServerChanged(newContext, currentContext)
                 || hasNewToken(newContext, newConfig, currentContext, currentConfig);
     }


### PR DESCRIPTION
It resolves #144 
This is no a direct patch for #144 as i guess it was solved partially with #145 but i found another issue while testing it. 

I found out that if you changed the config on runtime the tree didn't refresh correctly. The problem is that the client (DefaultKubernetesClient) is initialized with a config but if it changes somehow, the tkn client doesn't get recreated. So if you are logged in as an admin and you change to a developer, the tkn client (initialized as admin) keeps working with that config.

To test it, i started crc without being logged in. Then i started the plugin. The tree contained only the root and a warning node to tell i wasn't logged in. Then i logged in as admin and then switched to developer. 
Before this patch the tree didn't refresh. With this, the tree nodes are displayed correctly.