### PR TITLE
added runAfter code completion (#152)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/DictionaryContributor.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/DictionaryContributor.java
@@ -22,6 +22,10 @@ public class DictionaryContributor extends CompletionContributor {
         extend(CompletionType.BASIC,
                 YamlElementPatternHelper.getSingleLineScalarKey("conditionRef"),
                 new ConditionCompletionProvider());
+        // runAfter
+        extend(CompletionType.BASIC,
+                YamlElementPatternHelper.getMultipleLineScalarKey("runAfter"),
+                new RunAfterCompletionProvider());
         // general tekton snippets
         extend(CompletionType.BASIC,
                 PlatformPatterns.psiElement(PlainTextTokenTypes.PLAIN_TEXT),

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/RunAfterCompletionProvider.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/RunAfterCompletionProvider.java
@@ -67,7 +67,7 @@ public class RunAfterCompletionProvider extends CompletionProvider<CompletionPar
                 for (JsonNode item : tasksNode) {
                     if (item != null && cont != taskPosition) {
                         String name = item.has("name") ? item.get("name").asText("") : "";
-                        if (!name.isEmpty() && !Arrays.asList(tasksAlreadyAdded).contains(name)) {
+                        if (!name.isEmpty() && !tasksAlreadyAdded.contains(name)) {
                             lookups.add(0, LookupElementBuilder.create(name)
                                     .withPresentableText(name)
                                     .withLookupString(name));

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/RunAfterCompletionProvider.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/RunAfterCompletionProvider.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.completion;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.intellij.codeInsight.completion.CompletionParameters;
+import com.intellij.codeInsight.completion.CompletionProvider;
+import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.util.ProcessingContext;
+import com.redhat.devtools.intellij.common.utils.YAMLHelper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RunAfterCompletionProvider extends CompletionProvider<CompletionParameters> {
+    Logger logger = LoggerFactory.getLogger(ConditionCompletionProvider.class);
+
+    @Override
+    protected void addCompletions(@NotNull CompletionParameters parameters, @NotNull ProcessingContext context, @NotNull CompletionResultSet result) {
+        result.addAllElements(getTasksLookups(parameters));
+        result.stopHere();
+    }
+
+    private List<LookupElementBuilder> getTasksLookups(CompletionParameters parameters) {
+        List<LookupElementBuilder> lookups = new ArrayList<>();
+
+        try {
+            // get the list of tasks already added in the runAfter array to avoid showing them again
+            String[] tasksAlreadyAdded = parameters.getPosition().getParent().getParent().getParent().getText().split("\n");
+            tasksAlreadyAdded = Arrays.stream(tasksAlreadyAdded).map(task -> task.trim().replaceFirst("- ", "")).toArray(String[]::new);
+
+            // get current task node
+            PsiElement currentTask = parameters.getPosition().getParent().getParent().getParent().getParent().getParent().getContext();
+
+            // get all tasks node found in the pipeline before the selected one
+            String yamlUntilTask = parameters.getEditor().getDocument().getText(new TextRange(0, currentTask.getTextOffset()));
+            JsonNode tasksNode = YAMLHelper.getValueFromYAML(yamlUntilTask, new String[]{"spec", "tasks"} );
+            if (tasksNode != null) {
+                for (JsonNode item : tasksNode) {
+                    if (item != null) {
+                        String name = item.get("name").asText("");
+                        if (!name.isEmpty() && !Arrays.asList(tasksAlreadyAdded).contains(name)) {
+                            lookups.add(0, LookupElementBuilder.create(name)
+                                    .withPresentableText(name)
+                                    .withLookupString(name));
+                        }
+                    }
+                }
+            }
+        } catch (IOException e) {
+            logger.warn("Error: " + e.getLocalizedMessage());
+        }
+
+        return lookups;
+    }
+}
+

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/YamlElementPatternHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/YamlElementPatternHelper.java
@@ -17,6 +17,8 @@ import org.jetbrains.yaml.YAMLLanguage;
 import org.jetbrains.yaml.YAMLTokenTypes;
 import org.jetbrains.yaml.psi.YAMLKeyValue;
 import org.jetbrains.yaml.psi.YAMLScalar;
+import org.jetbrains.yaml.psi.YAMLSequence;
+import org.jetbrains.yaml.psi.YAMLSequenceItem;
 
 public class YamlElementPatternHelper {
     public static ElementPattern<PsiElement> getSingleLineScalarKey(String... keyName) {
@@ -33,6 +35,37 @@ public class YamlElementPatternHelper {
                                                      PlatformPatterns.string().oneOf(keyName)
                                              )
                              )
+                )
+                .withLanguage(YAMLLanguage.INSTANCE);
+
+    }
+
+
+    public static ElementPattern<PsiElement> getMultipleLineScalarKey(String keyName) {
+        // it finds
+        // key:
+        //  - "value"
+        //  - "value 1"
+        return PlatformPatterns
+                .psiElement(YAMLTokenTypes.TEXT)
+                .withParent(
+                        PlatformPatterns
+                            .psiElement(YAMLScalar.class)
+                            .withParent(
+                                PlatformPatterns.
+                                    psiElement(YAMLSequenceItem.class)
+                                    .withParent(
+                                            PlatformPatterns.
+                                                psiElement(YAMLSequence.class)
+                                                .withParent(
+                                                        PlatformPatterns
+                                                            .psiElement(YAMLKeyValue.class)
+                                                            .withName(
+                                                                    PlatformPatterns.string().equalTo(keyName)
+                                                            )
+                                                )
+                                    )
+                            )
                 )
                 .withLanguage(YAMLLanguage.INSTANCE);
 

--- a/src/test/java/com/redhat/devtools/intellij/tektoncd/completion/RunAfterCompletionProviderTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/tektoncd/completion/RunAfterCompletionProviderTest.java
@@ -47,31 +47,27 @@ public class RunAfterCompletionProviderTest {
 
     @Test
     public void testCompletionWithASingleLookup() {
-        testCompletion(new String[] { "pipeline1.yaml"}, "step1");
+        assertOrderedEquals(getSuggestionsForFile("pipeline1.yaml"), "step1");
     }
 
     @Test
     public void testCompletionWithMultipleLookups() {
-        testCompletion(new String[] { "pipeline2.yaml"}, "step2", "step3");
+        assertOrderedEquals(getSuggestionsForFile("pipeline2.yaml"), "step2", "step3");
     }
 
     @Test
     public void testCompletionWithMultipleLookupsAndTasksAlreadyUsed() {
-        testCompletion(new String[] { "pipeline3.yaml"}, "step4", "step5");
+        assertOrderedEquals(getSuggestionsForFile("pipeline3.yaml"), "step4", "step5");
     }
 
     @Test
     public void testCompletionWithNoLookups() {
-        myFixture.configureByFiles(new String[] { "pipeline4.yaml"});
-        myFixture.complete(CompletionType.BASIC, 1);
-        final List<String> strings = myFixture.getLookupElementStrings();
-        assertTrue(strings.isEmpty());
+        assertTrue(getSuggestionsForFile("pipeline4.yaml").isEmpty());
     }
 
-    private void testCompletion(String[] fileNames, String... expectedSuggestions) {
-        myFixture.configureByFiles(fileNames);
-        myFixture.complete(CompletionType.BASIC, 1);
-        final List<String> strings = myFixture.getLookupElementStrings();
-        assertOrderedEquals(strings, expectedSuggestions);
+    private List<String> getSuggestionsForFile(String fileName) {
+        myFixture.configureByFile(fileName);
+        myFixture.complete(CompletionType.BASIC);
+        return myFixture.getLookupElementStrings();
     }
 }

--- a/src/test/java/com/redhat/devtools/intellij/tektoncd/completion/RunAfterCompletionProviderTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/tektoncd/completion/RunAfterCompletionProviderTest.java
@@ -11,10 +11,12 @@
 package com.redhat.devtools.intellij.tektoncd.completion;
 
 import com.intellij.codeInsight.completion.CompletionType;
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess;
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture;
 import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory;
 import com.intellij.testFramework.fixtures.TestFixtureBuilder;
+import java.io.File;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
@@ -38,6 +40,7 @@ public class RunAfterCompletionProviderTest {
 
         myFixture.setTestDataPath("src/test/resources/completion");
         myFixture.setUp();
+        VfsRootAccess.allowRootAccess(new File("src").getAbsoluteFile().getParentFile().getAbsolutePath());
     }
 
     @After

--- a/src/test/java/com/redhat/devtools/intellij/tektoncd/completion/RunAfterCompletionProviderTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/tektoncd/completion/RunAfterCompletionProviderTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.completion;
+
+import com.intellij.codeInsight.completion.CompletionType;
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture;
+import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
+import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory;
+import com.intellij.testFramework.fixtures.TestFixtureBuilder;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+
+import static com.intellij.testFramework.UsefulTestCase.assertOrderedEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RunAfterCompletionProviderTest {
+
+    private CodeInsightTestFixture myFixture;
+
+    @Before
+    public void setup() throws Exception {
+        IdeaTestFixtureFactory factory = IdeaTestFixtureFactory.getFixtureFactory();
+        TestFixtureBuilder<IdeaProjectTestFixture> fixtureBuilder = factory.createLightFixtureBuilder(null);
+        IdeaProjectTestFixture fixture = fixtureBuilder.getFixture();
+
+        myFixture = IdeaTestFixtureFactory.getFixtureFactory().createCodeInsightFixture(fixture, factory.createTempDirTestFixture());
+
+        myFixture.setTestDataPath("src/test/resources/completion");
+        myFixture.setUp();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        myFixture.tearDown();
+    }
+
+    @Test
+    public void testCompletionWithASingleLookup() {
+        testCompletion(new String[] { "pipeline1.yaml"}, "step1");
+    }
+
+    @Test
+    public void testCompletionWithMultipleLookups() {
+        testCompletion(new String[] { "pipeline2.yaml"}, "step2", "step3");
+    }
+
+    @Test
+    public void testCompletionWithMultipleLookupsAndTasksAlreadyUsed() {
+        testCompletion(new String[] { "pipeline3.yaml"}, "step4", "step5");
+    }
+
+    @Test
+    public void testCompletionWithNoLookups() {
+        myFixture.configureByFiles(new String[] { "pipeline4.yaml"});
+        myFixture.complete(CompletionType.BASIC, 1);
+        final List<String> strings = myFixture.getLookupElementStrings();
+        assertTrue(strings.isEmpty());
+    }
+
+    private void testCompletion(String[] fileNames, String... expectedSuggestions) {
+        myFixture.configureByFiles(fileNames);
+        myFixture.complete(CompletionType.BASIC, 1);
+        final List<String> strings = myFixture.getLookupElementStrings();
+        assertOrderedEquals(strings, expectedSuggestions);
+    }
+}

--- a/src/test/resources/completion/pipeline1.yaml
+++ b/src/test/resources/completion/pipeline1.yaml
@@ -1,0 +1,15 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: foo
+  namespace: tekton
+spec:
+  tasks:
+    - name: step1
+      taskRef:
+        name: task1
+    - name: step2
+      taskRef:
+        name: task1
+      runAfter:
+        - <caret>

--- a/src/test/resources/completion/pipeline2.yaml
+++ b/src/test/resources/completion/pipeline2.yaml
@@ -1,0 +1,18 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: foo
+  namespace: tekton
+spec:
+  tasks:
+    - name: step1
+      taskRef:
+        name: task1
+      runAfter:
+        - <caret>
+    - name: step2
+      taskRef:
+        name: task1
+    - name: step3
+      taskRef:
+        name: task2

--- a/src/test/resources/completion/pipeline3.yaml
+++ b/src/test/resources/completion/pipeline3.yaml
@@ -1,0 +1,26 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: foo
+  namespace: tekton
+spec:
+  tasks:
+    - name: step1
+      taskRef:
+        name: task1
+      runAfter:
+        - step2
+        - step3
+        - <caret>
+    - name: step2
+      taskRef:
+        name: task1
+    - name: step3
+      taskRef:
+        name: task2
+    - name: step4
+      taskRef:
+        name: task2
+    - name: step5
+      taskRef:
+        name: task2

--- a/src/test/resources/completion/pipeline4.yaml
+++ b/src/test/resources/completion/pipeline4.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: foo
+  namespace: tekton
+spec:
+  tasks:
+    - name: step1
+      taskRef:
+        name: task1
+      runAfter:
+        - <caret>


### PR DESCRIPTION
it resolves #152 

This patch adds code completion for the runAfter tag. When the code completion is requested, it gets all tasks placed earlier in the pipeline than the one selected and shows them in the options. Below a demo.

![runAfter](https://user-images.githubusercontent.com/49404737/91053073-99b0d180-e622-11ea-906e-10ea0cb9ac0c.gif)
