### PR TITLE
Open start wizard with data from previous *run

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/Constants.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/Constants.java
@@ -31,6 +31,8 @@ public class Constants {
 
     public static final String KIND_PIPELINE = "pipeline";
     public static final String KIND_PIPELINERUN = "pipelinerun";
+    public static final String KIND_TASK = "task";
+    public static final String KIND_CLUSTERTASK = "clustertask";
     public static final String KIND_TASKRUN = "taskrun";
 
     public static final String KIND_PVC =  "PersistentVolumeClaim";

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/MirrorStartAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/MirrorStartAction.java
@@ -22,9 +22,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class StartMirrorRunAction extends StartAction {
+public class MirrorStartAction extends StartAction {
 
-    public StartMirrorRunAction() { super(PipelineRunNode.class, TaskRunNode.class); }
+    public MirrorStartAction() { super(PipelineRunNode.class, TaskRunNode.class); }
 
     @Override
     protected StartResourceModel getModel(ParentableNode element, String namespace, Tkn tkncli, List<Resource> resources, List<String> serviceAccounts, List<String> secrets, List<String> configMaps, List<String> persistentVolumeClaims) throws IOException {

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/StartAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/StartAction.java
@@ -21,6 +21,7 @@ import com.redhat.devtools.intellij.common.utils.UIHelper;
 import com.redhat.devtools.intellij.tektoncd.Constants;
 import com.redhat.devtools.intellij.tektoncd.actions.logs.FollowLogsAction;
 import com.redhat.devtools.intellij.tektoncd.tkn.Resource;
+import com.redhat.devtools.intellij.tektoncd.tkn.Run;
 import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Workspace;
 import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
@@ -30,6 +31,7 @@ import com.redhat.devtools.intellij.tektoncd.tree.TektonTreeStructure;
 import com.redhat.devtools.intellij.tektoncd.ui.wizard.StartWizard;
 import com.redhat.devtools.intellij.tektoncd.utils.StartResourceModel;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.swing.tree.TreePath;
@@ -87,7 +89,7 @@ public class StartAction extends TektonAction {
                     } else {
                         titleDialog = "Task " + element.getName();
                     }
-                    StartWizard wizard = new StartWizard(titleDialog, getEventProject(anActionEvent), model);
+                    StartWizard wizard = new StartWizard(titleDialog, element, getEventProject(anActionEvent), model);
                     wizard.show();
                     return wizard;
                 });
@@ -128,11 +130,14 @@ public class StartAction extends TektonAction {
 
     protected StartResourceModel getModel(ParentableNode element, String namespace, Tkn tkncli, List<Resource> resources, List<String> serviceAccounts, List<String> secrets, List<String> configMaps, List<String> persistentVolumeClaims) throws IOException {
         String configuration = "";
+        List<? extends Run> runs = new ArrayList<>();
         if (element instanceof PipelineNode) {
             configuration = tkncli.getPipelineYAML(namespace, element.getName());
+            runs = tkncli.getPipelineRuns(namespace, element.getName());
         } else if (element instanceof TaskNode) {
             configuration = tkncli.getTaskYAML(namespace, element.getName());
+            runs = tkncli.getTaskRuns(namespace, element.getName());
         }
-        return new StartResourceModel(configuration, resources, serviceAccounts, secrets, configMaps, persistentVolumeClaims);
+        return new StartResourceModel(configuration, resources, serviceAccounts, secrets, configMaps, persistentVolumeClaims, runs);
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/StartMirrorRunAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/StartMirrorRunAction.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.actions;
+
+import com.google.common.base.Strings;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.ui.Messages;
+import com.redhat.devtools.intellij.common.utils.ExecHelper;
+import com.redhat.devtools.intellij.common.utils.UIHelper;
+import com.redhat.devtools.intellij.common.utils.YAMLHelper;
+import com.redhat.devtools.intellij.tektoncd.Constants;
+import com.redhat.devtools.intellij.tektoncd.actions.logs.FollowLogsAction;
+import com.redhat.devtools.intellij.tektoncd.tkn.Resource;
+import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
+import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Workspace;
+import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
+import com.redhat.devtools.intellij.tektoncd.tree.PipelineNode;
+import com.redhat.devtools.intellij.tektoncd.tree.PipelineRunNode;
+import com.redhat.devtools.intellij.tektoncd.tree.TaskNode;
+import com.redhat.devtools.intellij.tektoncd.tree.TaskRunNode;
+import com.redhat.devtools.intellij.tektoncd.tree.TektonTreeStructure;
+import com.redhat.devtools.intellij.tektoncd.ui.wizard.StartWizard;
+import com.redhat.devtools.intellij.tektoncd.utils.StartResourceModel;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import javax.swing.tree.TreePath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+import static com.redhat.devtools.intellij.tektoncd.Constants.NOTIFICATION_ID;
+
+public class StartMirrorRunAction extends TektonAction {
+    private static final Logger logger = LoggerFactory.getLogger(StartMirrorRunAction.class);
+
+    public StartMirrorRunAction() { super(PipelineRunNode.class, TaskRunNode.class); }
+
+    @Override
+    public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Tkn tkncli) {
+        ParentableNode element = getElement(selected);
+        String namespace = element.getNamespace();
+        ExecHelper.submit(() -> {
+            String configuration = null;
+            String runConfiguration = null;
+            Notification notification;
+            List<Resource> resources;
+            List<String> serviceAccounts, secrets, configMaps, persistentVolumeClaims;
+            try {
+                if (element instanceof PipelineRunNode) {
+                    runConfiguration = tkncli.getPipelineRunYAML(namespace, element.getName());
+                    String pipeline = YAMLHelper.getStringValueFromYAML(runConfiguration, new String[] {"metadata", "labels", "tekton.dev/pipeline"});
+                    if (Strings.isNullOrEmpty(pipeline)) {
+                        return;
+                    }
+                    configuration = tkncli.getPipelineYAML(namespace, pipeline);
+                } else if (element instanceof TaskRunNode) {
+                    runConfiguration = tkncli.getTaskRunYAML(namespace, element.getName());
+                    String task = YAMLHelper.getStringValueFromYAML(runConfiguration, new String[] {"metadata", "labels", "tekton.dev/task"});
+                    if (Strings.isNullOrEmpty(task)) {
+                        return;
+                    }
+                    configuration = tkncli.getTaskYAML(namespace, task);
+                }
+                resources = tkncli.getResources(namespace);
+                serviceAccounts = tkncli.getServiceAccounts(namespace);
+                secrets = tkncli.getSecrets(namespace);
+                configMaps = tkncli.getConfigMaps(namespace);
+                persistentVolumeClaims = tkncli.getPersistentVolumeClaim(namespace);
+            } catch (IOException e) {
+                UIHelper.executeInUI(() ->
+                        Messages.showErrorDialog(
+                                element.getName() + " in namespace " + namespace + " failed to start. An error occurred while retrieving information.\n" + e.getLocalizedMessage(),
+                                "Error"));
+                logger.warn("Error: " + e.getLocalizedMessage());
+                return;
+            }
+
+            StartResourceModel model = new StartResourceModel(configuration, resources, serviceAccounts, secrets, configMaps, persistentVolumeClaims);
+
+            if (!model.isValid()) {
+                UIHelper.executeInUI(() -> Messages.showErrorDialog(model.getErrorMessage(), "Error"));
+                return;
+            }
+
+            boolean noInputsAndOuputs = model.getInputs().isEmpty() && model.getOutputs().isEmpty() && model.getWorkspaces().isEmpty();
+            StartWizard startWizard = null;
+
+            if (!noInputsAndOuputs) {
+                startWizard = UIHelper.executeInUI(() -> {
+                    String titleDialog;
+                    if (element instanceof PipelineNode) {
+                        titleDialog = "Pipeline " + element.getName();
+                    } else {
+                        titleDialog = "Task " + element.getName();
+                    }
+                    StartWizard wizard = new StartWizard(titleDialog, getEventProject(anActionEvent), model);
+                    wizard.show();
+                    return wizard;
+                });
+            }
+            if (noInputsAndOuputs || startWizard.isOK()) {
+                try {
+                    String serviceAccount = model.getServiceAccount();
+                    Map<String, String> taskServiceAccount = model.getTaskServiceAccounts();
+                    Map<String, String> params = model.getParameters();
+                    Map<String, Workspace> workspaces = model.getWorkspaces();
+                    Map<String, String> inputResources = model.getInputResources();
+                    Map<String, String> outputResources = model.getOutputResources();
+                    String runName = null;
+                    if (element instanceof PipelineNode) {
+                        runName = tkncli.startPipeline(namespace, element.getName(), params, inputResources, serviceAccount, taskServiceAccount, workspaces);
+
+                    } else if (element instanceof TaskNode) {
+                        runName = tkncli.startTask(namespace, element.getName(), params, inputResources, outputResources, serviceAccount, workspaces);
+                    }
+                    if(runName != null) {
+                        FollowLogsAction followLogsAction = (FollowLogsAction) ActionManager.getInstance().getAction("FollowLogsAction");
+                        followLogsAction.actionPerformed(namespace, runName, element.getClass(), tkncli);
+                    }
+                    ((TektonTreeStructure)getTree(anActionEvent).getClientProperty(Constants.STRUCTURE_PROPERTY)).fireModified(element);
+                } catch (IOException e) {
+                    notification = new Notification(NOTIFICATION_ID,
+                            "Error",
+                            element.getName() + " in namespace " + namespace + " failed to start\n" + e.getLocalizedMessage(),
+                            NotificationType.ERROR);
+                    Notifications.Bus.notify(notification);
+                    logger.warn("Error: " + e.getLocalizedMessage());
+                }
+            }
+        });
+    }
+
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/StartMirrorRunAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/StartMirrorRunAction.java
@@ -12,12 +12,14 @@ package com.redhat.devtools.intellij.tektoncd.actions;
 
 import com.redhat.devtools.intellij.common.utils.YAMLHelper;
 import com.redhat.devtools.intellij.tektoncd.tkn.Resource;
+import com.redhat.devtools.intellij.tektoncd.tkn.Run;
 import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
 import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
 import com.redhat.devtools.intellij.tektoncd.tree.PipelineRunNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TaskRunNode;
 import com.redhat.devtools.intellij.tektoncd.utils.StartResourceModel;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 public class StartMirrorRunAction extends StartAction {
@@ -27,17 +29,20 @@ public class StartMirrorRunAction extends StartAction {
     @Override
     protected StartResourceModel getModel(ParentableNode element, String namespace, Tkn tkncli, List<Resource> resources, List<String> serviceAccounts, List<String> secrets, List<String> configMaps, List<String> persistentVolumeClaims) throws IOException {
         String configuration = "", runConfiguration = "";
+        List<? extends Run> runs = new ArrayList<>();
         if (element instanceof PipelineRunNode) {
             runConfiguration = tkncli.getPipelineRunYAML(namespace, element.getName());
             String pipeline = YAMLHelper.getStringValueFromYAML(runConfiguration, new String[] {"metadata", "labels", "tekton.dev/pipeline"});
             configuration = tkncli.getPipelineYAML(namespace, pipeline);
+            runs = tkncli.getPipelineRuns(namespace, pipeline);
         } else if (element instanceof TaskRunNode) {
             runConfiguration = tkncli.getTaskRunYAML(namespace, element.getName());
             String task = YAMLHelper.getStringValueFromYAML(runConfiguration, new String[] {"metadata", "labels", "tekton.dev/task"});
             configuration = tkncli.getTaskYAML(namespace, task);
+            runs = tkncli.getTaskRuns(namespace, task);
         }
 
-        StartResourceModel model = new StartResourceModel(configuration, resources, serviceAccounts, secrets, configMaps, persistentVolumeClaims);
+        StartResourceModel model = new StartResourceModel(configuration, resources, serviceAccounts, secrets, configMaps, persistentVolumeClaims, runs);
         model.adaptsToRun(runConfiguration);
         return model;
     }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/StartMirrorRunAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/StartMirrorRunAction.java
@@ -10,137 +10,35 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.tektoncd.actions;
 
-import com.google.common.base.Strings;
-import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationType;
-import com.intellij.notification.Notifications;
-import com.intellij.openapi.actionSystem.ActionManager;
-import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.ui.Messages;
-import com.redhat.devtools.intellij.common.utils.ExecHelper;
-import com.redhat.devtools.intellij.common.utils.UIHelper;
 import com.redhat.devtools.intellij.common.utils.YAMLHelper;
-import com.redhat.devtools.intellij.tektoncd.Constants;
-import com.redhat.devtools.intellij.tektoncd.actions.logs.FollowLogsAction;
 import com.redhat.devtools.intellij.tektoncd.tkn.Resource;
 import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
-import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Workspace;
 import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
-import com.redhat.devtools.intellij.tektoncd.tree.PipelineNode;
 import com.redhat.devtools.intellij.tektoncd.tree.PipelineRunNode;
-import com.redhat.devtools.intellij.tektoncd.tree.TaskNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TaskRunNode;
-import com.redhat.devtools.intellij.tektoncd.tree.TektonTreeStructure;
-import com.redhat.devtools.intellij.tektoncd.ui.wizard.StartWizard;
 import com.redhat.devtools.intellij.tektoncd.utils.StartResourceModel;
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
-import javax.swing.tree.TreePath;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-
-import static com.redhat.devtools.intellij.tektoncd.Constants.NOTIFICATION_ID;
-
-public class StartMirrorRunAction extends TektonAction {
-    private static final Logger logger = LoggerFactory.getLogger(StartMirrorRunAction.class);
+public class StartMirrorRunAction extends StartAction {
 
     public StartMirrorRunAction() { super(PipelineRunNode.class, TaskRunNode.class); }
 
     @Override
-    public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Tkn tkncli) {
-        ParentableNode element = getElement(selected);
-        String namespace = element.getNamespace();
-        ExecHelper.submit(() -> {
-            String configuration = null;
-            String runConfiguration = null;
-            Notification notification;
-            List<Resource> resources;
-            List<String> serviceAccounts, secrets, configMaps, persistentVolumeClaims;
-            try {
-                if (element instanceof PipelineRunNode) {
-                    runConfiguration = tkncli.getPipelineRunYAML(namespace, element.getName());
-                    String pipeline = YAMLHelper.getStringValueFromYAML(runConfiguration, new String[] {"metadata", "labels", "tekton.dev/pipeline"});
-                    if (Strings.isNullOrEmpty(pipeline)) {
-                        return;
-                    }
-                    configuration = tkncli.getPipelineYAML(namespace, pipeline);
-                } else if (element instanceof TaskRunNode) {
-                    runConfiguration = tkncli.getTaskRunYAML(namespace, element.getName());
-                    String task = YAMLHelper.getStringValueFromYAML(runConfiguration, new String[] {"metadata", "labels", "tekton.dev/task"});
-                    if (Strings.isNullOrEmpty(task)) {
-                        return;
-                    }
-                    configuration = tkncli.getTaskYAML(namespace, task);
-                }
-                resources = tkncli.getResources(namespace);
-                serviceAccounts = tkncli.getServiceAccounts(namespace);
-                secrets = tkncli.getSecrets(namespace);
-                configMaps = tkncli.getConfigMaps(namespace);
-                persistentVolumeClaims = tkncli.getPersistentVolumeClaim(namespace);
-            } catch (IOException e) {
-                UIHelper.executeInUI(() ->
-                        Messages.showErrorDialog(
-                                element.getName() + " in namespace " + namespace + " failed to start. An error occurred while retrieving information.\n" + e.getLocalizedMessage(),
-                                "Error"));
-                logger.warn("Error: " + e.getLocalizedMessage());
-                return;
-            }
+    protected StartResourceModel getModel(ParentableNode element, String namespace, Tkn tkncli, List<Resource> resources, List<String> serviceAccounts, List<String> secrets, List<String> configMaps, List<String> persistentVolumeClaims) throws IOException {
+        String configuration = "", runConfiguration = "";
+        if (element instanceof PipelineRunNode) {
+            runConfiguration = tkncli.getPipelineRunYAML(namespace, element.getName());
+            String pipeline = YAMLHelper.getStringValueFromYAML(runConfiguration, new String[] {"metadata", "labels", "tekton.dev/pipeline"});
+            configuration = tkncli.getPipelineYAML(namespace, pipeline);
+        } else if (element instanceof TaskRunNode) {
+            runConfiguration = tkncli.getTaskRunYAML(namespace, element.getName());
+            String task = YAMLHelper.getStringValueFromYAML(runConfiguration, new String[] {"metadata", "labels", "tekton.dev/task"});
+            configuration = tkncli.getTaskYAML(namespace, task);
+        }
 
-            StartResourceModel model = new StartResourceModel(configuration, resources, serviceAccounts, secrets, configMaps, persistentVolumeClaims);
-
-            if (!model.isValid()) {
-                UIHelper.executeInUI(() -> Messages.showErrorDialog(model.getErrorMessage(), "Error"));
-                return;
-            }
-
-            boolean noInputsAndOuputs = model.getInputs().isEmpty() && model.getOutputs().isEmpty() && model.getWorkspaces().isEmpty();
-            StartWizard startWizard = null;
-
-            if (!noInputsAndOuputs) {
-                startWizard = UIHelper.executeInUI(() -> {
-                    String titleDialog;
-                    if (element instanceof PipelineNode) {
-                        titleDialog = "Pipeline " + element.getName();
-                    } else {
-                        titleDialog = "Task " + element.getName();
-                    }
-                    StartWizard wizard = new StartWizard(titleDialog, getEventProject(anActionEvent), model);
-                    wizard.show();
-                    return wizard;
-                });
-            }
-            if (noInputsAndOuputs || startWizard.isOK()) {
-                try {
-                    String serviceAccount = model.getServiceAccount();
-                    Map<String, String> taskServiceAccount = model.getTaskServiceAccounts();
-                    Map<String, String> params = model.getParameters();
-                    Map<String, Workspace> workspaces = model.getWorkspaces();
-                    Map<String, String> inputResources = model.getInputResources();
-                    Map<String, String> outputResources = model.getOutputResources();
-                    String runName = null;
-                    if (element instanceof PipelineNode) {
-                        runName = tkncli.startPipeline(namespace, element.getName(), params, inputResources, serviceAccount, taskServiceAccount, workspaces);
-
-                    } else if (element instanceof TaskNode) {
-                        runName = tkncli.startTask(namespace, element.getName(), params, inputResources, outputResources, serviceAccount, workspaces);
-                    }
-                    if(runName != null) {
-                        FollowLogsAction followLogsAction = (FollowLogsAction) ActionManager.getInstance().getAction("FollowLogsAction");
-                        followLogsAction.actionPerformed(namespace, runName, element.getClass(), tkncli);
-                    }
-                    ((TektonTreeStructure)getTree(anActionEvent).getClientProperty(Constants.STRUCTURE_PROPERTY)).fireModified(element);
-                } catch (IOException e) {
-                    notification = new Notification(NOTIFICATION_ID,
-                            "Error",
-                            element.getName() + " in namespace " + namespace + " failed to start\n" + e.getLocalizedMessage(),
-                            NotificationType.ERROR);
-                    Notifications.Bus.notify(notification);
-                    logger.warn("Error: " + e.getLocalizedMessage());
-                }
-            }
-        });
+        StartResourceModel model = new StartResourceModel(configuration, resources, serviceAccounts, secrets, configMaps, persistentVolumeClaims);
+        model.adaptsToRun(runConfiguration);
+        return model;
     }
-
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/GeneralCompletionProvider.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/GeneralCompletionProvider.java
@@ -19,6 +19,9 @@ import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Output;
 import com.redhat.devtools.intellij.tektoncd.utils.model.ConfigurationModel;
 import com.redhat.devtools.intellij.tektoncd.utils.model.ConfigurationModelFactory;
+import com.redhat.devtools.intellij.tektoncd.utils.model.resources.ConditionConfigurationModel;
+import com.redhat.devtools.intellij.tektoncd.utils.model.resources.PipelineConfigurationModel;
+import com.redhat.devtools.intellij.tektoncd.utils.model.resources.TaskConfigurationModel;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -112,7 +115,7 @@ public class GeneralCompletionProvider extends CompletionProvider<CompletionPara
      * @return
      */
     private List<LookupElementBuilder> getLookupsPipeline(ConfigurationModel model, String prefix, String completionPrefix, int insertOffset) {
-        return getParamLookups(model.getParams(), prefix, completionPrefix, insertOffset);
+        return getParamLookups(((PipelineConfigurationModel)model).getParams(), prefix, completionPrefix, insertOffset);
     }
 
     /**
@@ -127,21 +130,21 @@ public class GeneralCompletionProvider extends CompletionProvider<CompletionPara
     private List<LookupElementBuilder> getLookupsTask(ConfigurationModel model, String prefix, String completionPrefix, int insertOffset) {
         List<LookupElementBuilder> lookups = new ArrayList<>();
         // get lookups for params
-        lookups.addAll(getParamLookups(model.getParams(), prefix, completionPrefix, insertOffset));
+        lookups.addAll(getParamLookups(((TaskConfigurationModel)model).getParams(), prefix, completionPrefix, insertOffset));
 
         // get lookups for resources
         String headPrefix_19 = prefix.length() > 19 ? prefix.substring(0, 19) : prefix;
         if ("$(resources.inputs.".contains(headPrefix_19)) {
-            lookups.addAll(getInputResourceLookups(model.getInputResources(), "resources.inputs", prefix, completionPrefix, insertOffset));
+            lookups.addAll(getInputResourceLookups(((TaskConfigurationModel)model).getInputResources(), "resources.inputs", prefix, completionPrefix, insertOffset));
         }
 
         // get lookups for output resources
         String headPrefix_20 = prefix.length() > 20 ? prefix.substring(0, 20) : prefix;
         if ("$(resources.outputs.".contains(headPrefix_20)) {
-            lookups.addAll(getOutputResourceLookups(model.getOutputResources(), "resources.outputs", prefix, completionPrefix, insertOffset));
+            lookups.addAll(getOutputResourceLookups(((TaskConfigurationModel)model).getOutputResources(), "resources.outputs", prefix, completionPrefix, insertOffset));
         }
         // get lookups for workspaces
-        lookups.addAll(getWorkspaceLookups(model.getWorkspaces(), prefix, completionPrefix, insertOffset));
+        lookups.addAll(getWorkspaceLookups(((TaskConfigurationModel)model).getWorkspaces(), prefix, completionPrefix, insertOffset));
 
         return lookups;
     }
@@ -158,11 +161,11 @@ public class GeneralCompletionProvider extends CompletionProvider<CompletionPara
     private List<LookupElementBuilder> getLookupsCondition(ConfigurationModel model, String prefix, String completionPrefix, int insertOffset) {
         List<LookupElementBuilder> lookups = new ArrayList<>();
 
-        lookups.addAll(getParamLookups(model.getParams(), prefix, completionPrefix, insertOffset));
+        lookups.addAll(getParamLookups(((ConditionConfigurationModel)model).getParams(), prefix, completionPrefix, insertOffset));
 
         String headPrefix_12 = prefix.length() > 12 ? prefix.substring(0, 12) : prefix;
         if ("$(resources.".contains(headPrefix_12)) {
-            lookups.addAll(getInputResourceLookups(model.getInputResources(), "resources", prefix, completionPrefix, insertOffset));
+            lookups.addAll(getInputResourceLookups(((ConditionConfigurationModel)model).getInputResources(), "resources", prefix, completionPrefix, insertOffset));
         }
 
         return lookups;

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/component/field/Input.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/component/field/Input.java
@@ -46,6 +46,10 @@ public class Input {
         return defaultValue;
     }
 
+    public void setDefaultValue(String value) {
+        this.defaultValue = Optional.of(value);
+    }
+
     public String value() {
         return value;
     }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/AuthenticationStep.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/AuthenticationStep.java
@@ -61,16 +61,27 @@ public class AuthenticationStep extends BaseStep {
 
             JComboBox cmbValueResource = new JComboBox();
             cmbValueResource = (JComboBox) addComponent(cmbValueResource, TIMES_PLAIN_14, null, ROW_DIMENSION, 0, row[0], GridBagConstraints.NORTH);
-            fillComboBox(cmbValueResource);
+            fillComboBox(name, cmbValueResource);
             addListener(name, cmbValueResource);
             row[0] += 1;
         });
     }
 
-    private void fillComboBox(JComboBox comboBox) {
+    private void fillComboBox(String serviceAccountName, JComboBox comboBox) {
         comboBox.addItem("");
         for (String value : model.getServiceAccounts()) {
             comboBox.addItem(value);
+        }
+
+        if (serviceAccountName.equals("Global Service Account")) {
+            if (!model.getServiceAccount().isEmpty()) {
+                comboBox.setSelectedItem(model.getServiceAccount());
+            }
+        } else {
+            if (model.getTaskServiceAccounts().containsKey(serviceAccountName) &&
+                    !model.getTaskServiceAccounts().get(serviceAccountName).isEmpty()) {
+                comboBox.setSelectedItem(model.getTaskServiceAccounts().get(serviceAccountName));
+            }
         }
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/AuthenticationStep.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/AuthenticationStep.java
@@ -27,6 +27,8 @@ import static com.redhat.devtools.intellij.tektoncd.ui.UIConstants.TIMES_PLAIN_1
 
 public class AuthenticationStep extends BaseStep {
 
+    private static final String GLOBALSA = "Global Service Account";
+
     public AuthenticationStep(StartResourceModel model) {
         super("Authentication", model);
     }
@@ -45,7 +47,7 @@ public class AuthenticationStep extends BaseStep {
         final int[] row = {0};
 
         List<String> serviceAccounts = new ArrayList<>(model.getTaskServiceAccounts().keySet());
-        serviceAccounts.add(0, "Global Service Account");
+        serviceAccounts.add(0, GLOBALSA);
 
         serviceAccounts.forEach(name -> {
             if (row[0] == 2) {
@@ -67,20 +69,20 @@ public class AuthenticationStep extends BaseStep {
         });
     }
 
-    private void fillComboBox(String serviceAccountName, JComboBox comboBox) {
+    private void fillComboBox(String saAssociatedToComboBox, JComboBox comboBox) {
         comboBox.addItem("");
         for (String value : model.getServiceAccounts()) {
             comboBox.addItem(value);
         }
 
-        if (serviceAccountName.equals("Global Service Account")) {
+        if (saAssociatedToComboBox.equals(GLOBALSA)) {
             if (!model.getServiceAccount().isEmpty()) {
                 comboBox.setSelectedItem(model.getServiceAccount());
             }
         } else {
-            if (model.getTaskServiceAccounts().containsKey(serviceAccountName) &&
-                    !model.getTaskServiceAccounts().get(serviceAccountName).isEmpty()) {
-                comboBox.setSelectedItem(model.getTaskServiceAccounts().get(serviceAccountName));
+            if (model.getTaskServiceAccounts().containsKey(saAssociatedToComboBox) &&
+                    !model.getTaskServiceAccounts().get(saAssociatedToComboBox).isEmpty()) {
+                comboBox.setSelectedItem(model.getTaskServiceAccounts().get(saAssociatedToComboBox));
             }
         }
     }
@@ -91,7 +93,7 @@ public class AuthenticationStep extends BaseStep {
             // when combo box value change update sa value
             if (itemEvent.getStateChange() == 1) {
                 String serviceAccountSelected = (String) itemEvent.getItem();
-                if (idParam.equals("Global Service Account")) {
+                if (idParam.equals(GLOBALSA)) {
                     model.setServiceAccount(serviceAccountSelected);
                 } else {
                     model.getTaskServiceAccounts().put(idParam, serviceAccountSelected);

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/BaseStep.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/BaseStep.java
@@ -176,7 +176,6 @@ public abstract class BaseStep implements Step, Disposable {
 
     public void refresh() {
         contentPanel.removeAll();
-        //contentPanel.repaint();
         setContent(model);
         adjustContentPanel();
         contentPanel.revalidate();

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/BaseStep.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/BaseStep.java
@@ -176,8 +176,11 @@ public abstract class BaseStep implements Step, Disposable {
 
     public void refresh() {
         contentPanel.removeAll();
+        //contentPanel.repaint();
         setContent(model);
         adjustContentPanel();
+        contentPanel.revalidate();
+        contentPanel.repaint();
     }
 
     public abstract void setContent(StartResourceModel model);

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/BaseStep.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/BaseStep.java
@@ -174,6 +174,12 @@ public abstract class BaseStep implements Step, Disposable {
         }
     }
 
+    public void refresh() {
+        contentPanel.removeAll();
+        setContent(model);
+        adjustContentPanel();
+    }
+
     public abstract void setContent(StartResourceModel model);
     public abstract boolean isComplete();
     public abstract String getHelpId();

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/InputResourcesStep.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/InputResourcesStep.java
@@ -58,7 +58,7 @@ public class InputResourcesStep extends BaseStep {
     private void fillComboBox(JComboBox comboBox, Input input) {
         for (Resource resource: model.getResources()) {
             if (resource.type().equals(input.type())) {
-                comboBox.addItem(resource);
+                comboBox.addItem(resource.name());
             }
         }
         if (input.value() != null) {
@@ -71,8 +71,8 @@ public class InputResourcesStep extends BaseStep {
         cmbValueResource.addItemListener(itemEvent -> {
             if (itemEvent.getStateChange() == 1) {
                 // when inputResourceValuesCB combo box value changes, the new value is saved and preview is updated
-                Resource resourceSelected = (Resource) itemEvent.getItem();
-                setInputValue(idParam, resourceSelected.name());
+                String resourceSelected = (String) itemEvent.getItem();
+                setInputValue(idParam, resourceSelected);
                 fireStateChanged();
             }
         });

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/StartWizard.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/StartWizard.java
@@ -246,6 +246,9 @@ public class StartWizard extends DialogWrapper {
         // import data from *run
         JCheckBox chkImportRunData = new JCheckBox("Import data from run");
         chkImportRunData.setBackground(backgroundTheme);
+        JLabel warnNoRunsAvailable = new JLabel("No runs to choose from");
+        warnNoRunsAvailable.setVisible(false);
+        warnNoRunsAvailable.setForeground(Color.red);
         JComboBox cmbPickRunToImportData = new ComboBox();
         cmbPickRunToImportData.setVisible(false);
         cmbPickRunToImportData.setPreferredSize(ROW_DIMENSION);
@@ -253,8 +256,10 @@ public class StartWizard extends DialogWrapper {
         chkImportRunData.addItemListener(itemEvent -> {
             if (chkImportRunData.isSelected()) {
                 cmbPickRunToImportData.setVisible(true);
+                warnNoRunsAvailable.setVisible(true);
             } else {
                 cmbPickRunToImportData.setVisible(false);
+                warnNoRunsAvailable.setVisible(false);
             }
         });
         cmbPickRunToImportData.addItem("Please choose");
@@ -285,7 +290,7 @@ public class StartWizard extends DialogWrapper {
         });
 
         innerOptionsPanel.add(chkImportRunData);
-        innerOptionsPanel.add(cmbPickRunToImportData);
+        innerOptionsPanel.add(cmbPickRunToImportData.getItemCount() > 1 ? cmbPickRunToImportData : warnNoRunsAvailable);
         return innerOptionsPanel;
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/StartWizard.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/StartWizard.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.intellij.tektoncd.ui.wizard;
 
 import com.intellij.CommonBundle;
+import com.intellij.icons.AllIcons;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.ide.IdeBundle;
 import com.intellij.ide.wizard.CommitStepException;
@@ -20,6 +21,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.colors.ColorKey;
 import com.intellij.openapi.editor.colors.EditorColorsManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.ComboBox;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.Disposer;
@@ -30,14 +32,19 @@ import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.mac.TouchbarDataKeys;
 import com.intellij.util.ui.UIUtil;
 import com.intellij.util.ui.update.UiNotifyConnector;
+import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Output;
+import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
 import com.redhat.devtools.intellij.tektoncd.utils.StartResourceModel;
 import com.redhat.devtools.intellij.tektoncd.utils.YAMLBuilder;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.GridBagLayout;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -50,18 +57,24 @@ import javax.swing.BoxLayout;
 import javax.swing.GroupLayout;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextArea;
+import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
 import org.jetbrains.annotations.Nullable;
 
 
+import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_CLUSTERTASK;
+import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_PIPELINE;
+import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_TASK;
 import static com.redhat.devtools.intellij.tektoncd.ui.UIConstants.BLUE;
 import static com.redhat.devtools.intellij.tektoncd.ui.UIConstants.MARGIN_10;
 import static com.redhat.devtools.intellij.tektoncd.ui.UIConstants.NO_BORDER;
+import static com.redhat.devtools.intellij.tektoncd.ui.UIConstants.ROW_DIMENSION;
 import static com.redhat.devtools.intellij.tektoncd.ui.UIConstants.TIMES_PLAIN_14;
 
 public class StartWizard extends DialogWrapper {
@@ -79,6 +92,7 @@ public class StartWizard extends DialogWrapper {
     protected JPanel myRightPanel;
     protected JPanel myFooterPanel;
     private List<JLabel> navigationList;
+    private JPanel optionsPanel;
     private JPanel navigationPanel;
     private JPanel previewFooterPanel;
     private JTextArea previewTextArea;
@@ -86,11 +100,11 @@ public class StartWizard extends DialogWrapper {
 
     private JBCardLayout.SwipeDirection myTransitionDirection = JBCardLayout.SwipeDirection.AUTO;
 
-    public StartWizard(String title, @Nullable Project project, StartResourceModel model) {
+    public StartWizard(String title, ParentableNode element, @Nullable Project project, StartResourceModel model) {
         super(project, true);
         this.backgroundTheme = EditorColorsManager.getInstance().getGlobalScheme().getDefaultBackground();
         myTitle = title;
-        buildStructure();
+        buildStructure(model, element);
         myCurrentStep = 0;
         mySteps = getSteps(model);
         fill(model);
@@ -153,7 +167,7 @@ public class StartWizard extends DialogWrapper {
 
     }
 
-    private void buildStructure() {
+    private void buildStructure(StartResourceModel model, ParentableNode element) {
         myPreviousButton = new JButton(IdeBundle.message("button.wizard.previous"));
         myNextButton = new JButton(IdeBundle.message("button.wizard.next"));
         myCancelButton = new JButton(CommonBundle.getCancelButtonText());
@@ -164,6 +178,42 @@ public class StartWizard extends DialogWrapper {
         myLeftPanel = new JPanel(new JBCardLayout());
         myRightPanel = new JPanel(new BorderLayout());
         myFooterPanel = new JPanel(new BorderLayout());
+
+        JPanel innerOptionsPanel = getOptionsPanel(model, element);
+
+        optionsPanel = new JPanel();
+        optionsPanel.setBackground(backgroundTheme);
+        optionsPanel.add(innerOptionsPanel);
+        optionsPanel.setVisible(false);
+
+        JLabel openOptionsLabel = new JLabel("Advanced Options");
+        openOptionsLabel.setIcon(AllIcons.Actions.MoveDown);
+        openOptionsLabel.addMouseListener(
+                new MouseAdapter() {
+                    @Override
+                    public void mouseClicked(MouseEvent e) {
+                        if (optionsPanel.isVisible()) {
+                            openOptionsLabel.setIcon(AllIcons.Actions.MoveDown);
+                            optionsPanel.setVisible(false);
+                        } else {
+                            openOptionsLabel.setIcon(AllIcons.Actions.MoveUp);
+                            optionsPanel.setVisible(true);
+                        }
+                    }
+                }
+        );
+
+        JPanel openOptionsPanel = new JPanel(new GridBagLayout());
+        openOptionsPanel.setBackground(backgroundTheme);
+        Border lineSeparatorBelow = new MatteBorder(0, 0, 1, 0, EditorColorsManager.getInstance().getGlobalScheme().getColor(ColorKey.find("SEPARATOR_BELOW_COLOR")));
+        Border margin_5 = new EmptyBorder(5, 0, 5, 0);
+        Border compoundBorderMargin = BorderFactory.createCompoundBorder(lineSeparatorBelow, margin_5);
+        openOptionsPanel.setBorder(compoundBorderMargin);
+        openOptionsPanel.add(openOptionsLabel);
+
+        myHeaderPanel.setBackground(backgroundTheme);
+        myHeaderPanel.add(optionsPanel, BorderLayout.LINE_START);
+        myHeaderPanel.add(openOptionsPanel, BorderLayout.PAGE_END);
 
         myContentPanel.setBackground(backgroundTheme);
         myContentPanel.setPreferredSize(new Dimension(550, 400));
@@ -186,6 +236,57 @@ public class StartWizard extends DialogWrapper {
         } else {
             myFooterPanel.add(previewFooterPanel, BorderLayout.LINE_START);
         }
+    }
+
+    private JPanel getOptionsPanel(StartResourceModel model, ParentableNode element) {
+        JPanel innerOptionsPanel = new JPanel();
+        innerOptionsPanel.setBackground(backgroundTheme);
+        innerOptionsPanel.setBorder(MARGIN_10);
+
+        // import data from *run
+        JCheckBox chkImportRunData = new JCheckBox("Import data from run");
+        chkImportRunData.setBackground(backgroundTheme);
+        JComboBox cmbPickRunToImportData = new ComboBox();
+        cmbPickRunToImportData.setVisible(false);
+        cmbPickRunToImportData.setPreferredSize(ROW_DIMENSION);
+
+        chkImportRunData.addItemListener(itemEvent -> {
+            if (chkImportRunData.isSelected()) {
+                cmbPickRunToImportData.setVisible(true);
+            } else {
+                cmbPickRunToImportData.setVisible(false);
+            }
+        });
+        cmbPickRunToImportData.addItem("Please choose");
+        model.getRuns().forEach(run -> cmbPickRunToImportData.addItem(run.getName()));
+
+        cmbPickRunToImportData.addItemListener(itemEvent -> {
+            // when combo box value change
+            if (itemEvent.getStateChange() == 1) {
+                if (itemEvent.getItem().toString().equals("Please choose")) return;
+                Tkn tkncli = element.getRoot().getTkn();
+                String configuration = "";
+                String kind = model.getKind();
+                try {
+                    if (kind.equalsIgnoreCase(KIND_PIPELINE)) {
+                        configuration = tkncli.getPipelineRunYAML(element.getNamespace(), itemEvent.getItem().toString());
+                    } else if (kind.equalsIgnoreCase(KIND_TASK) || kind.equalsIgnoreCase(KIND_CLUSTERTASK)) {
+                        configuration = tkncli.getTaskRunYAML(element.getNamespace(), itemEvent.getItem().toString());
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+                if (!configuration.isEmpty()) {
+                    model.adaptsToRun(configuration);
+                    refreshSteps();
+                    updatePreview(model);
+                }
+            }
+        });
+
+        innerOptionsPanel.add(chkImportRunData);
+        innerOptionsPanel.add(cmbPickRunToImportData);
+        return innerOptionsPanel;
     }
 
     private List<BaseStep> getSteps(StartResourceModel model) {
@@ -535,6 +636,10 @@ public class StartWizard extends DialogWrapper {
         model.setParameters(parameters);
         model.setInputResources(inputResources);
         model.setOutputResources(outputResources);
+    }
+
+    private void refreshSteps() {
+        this.mySteps.forEach(step -> step.refresh());
     }
 
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/WorkspacesStep.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/WorkspacesStep.java
@@ -188,7 +188,7 @@ public class WorkspacesStep extends BaseStep {
         } else if(kind == SECRET) {
             items = model.getSecrets();
         } else if ( kind == PVC) {
-            items = model.getPersistenceVolumeClaims();
+            items = model.getPersistentVolumeClaims();
         }
         return items;
     }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/StartResourceModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/StartResourceModel.java
@@ -37,14 +37,13 @@ import static com.redhat.devtools.intellij.tektoncd.Constants.FLAG_INPUTRESOURCE
 import static com.redhat.devtools.intellij.tektoncd.Constants.FLAG_PARAMETER;
 import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_PIPELINE;
 
-public class StartResourceModel {
+public class StartResourceModel extends ConfigurationModel{
 
-    private String namespace, name, kind;
     private String serviceAccountName;
     private List<Input> inputs;
     private List<Output> outputs;
     private List<Resource> resources;
-    private List<String> serviceAccounts, secrets, configMaps, persistenceVolumeClaims;
+    private List<String> serviceAccounts, secrets, configMaps, persistentVolumeClaims;
     private boolean isValid = true;
     private String errorMessage;
     private Map<String, String> parameters, inputResources, outputResources, taskServiceAccountNames;
@@ -52,6 +51,7 @@ public class StartResourceModel {
     private List<? extends Run> runs;
 
     public StartResourceModel(String configuration, List<Resource> resources, List<String> serviceAccounts, List<String> secrets, List<String> configMaps, List<String> persistentVolumeClaims) {
+        super(configuration);
         this.errorMessage = "Tekton configuration has an invalid format:\n";
         this.inputs = Collections.emptyList();
         this.outputs = Collections.emptyList();
@@ -65,7 +65,7 @@ public class StartResourceModel {
         this.workspaces = Collections.emptyMap();
         this.secrets = secrets;
         this.configMaps = configMaps;
-        this.persistenceVolumeClaims = persistentVolumeClaims;
+        this.persistentVolumeClaims = persistentVolumeClaims;
 
         buildModel(configuration);
     }
@@ -77,17 +77,14 @@ public class StartResourceModel {
 
     private void buildModel(String configuration) {
         try {
-            this.namespace = YAMLHelper.getStringValueFromYAML(configuration, new String[] {"metadata", "namespace"});
             if (Strings.isNullOrEmpty(namespace)) {
                 errorMessage += " * Namespace field is missing or its value is not valid.\n";
                 isValid = false;
             }
-            this.name = YAMLHelper.getStringValueFromYAML(configuration, new String[] {"metadata", "name"});
-            if (Strings.isNullOrEmpty(this.name)) {
+            if (Strings.isNullOrEmpty(name)) {
                 errorMessage += " * Name field is missing or its value is not valid.\n";
                 isValid = false;
             }
-            this.kind = YAMLHelper.getStringValueFromYAML(configuration, new String[] {"kind"});
             if (Strings.isNullOrEmpty(kind)) {
                 errorMessage += " * Kind field is missing or its value is not valid.\n";
                 isValid = false;
@@ -243,18 +240,6 @@ public class StartResourceModel {
         return this.isValid;
     }
 
-    public String getNamespace() {
-        return this.namespace;
-    }
-
-    public String getName() {
-        return this.name;
-    }
-
-    public String getKind() {
-        return this.kind;
-    }
-
     public List<Input> getInputs() {
         return this.inputs;
     }
@@ -319,8 +304,8 @@ public class StartResourceModel {
         return this.configMaps;
     }
 
-    public List<String> getPersistenceVolumeClaims() {
-        return this.persistenceVolumeClaims;
+    public List<String> getPersistentVolumeClaims() {
+        return this.persistentVolumeClaims;
     }
 
     public List<? extends Run> getRuns() {

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/StartResourceModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/StartResourceModel.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Strings;
 import com.redhat.devtools.intellij.common.utils.YAMLHelper;
 import com.redhat.devtools.intellij.tektoncd.tkn.Resource;
+import com.redhat.devtools.intellij.tektoncd.tkn.Run;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Output;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Workspace;
@@ -48,8 +49,9 @@ public class StartResourceModel {
     private String errorMessage;
     private Map<String, String> parameters, inputResources, outputResources, taskServiceAccountNames;
     private Map<String, Workspace> workspaces;
+    private List<? extends Run> runs;
 
-    public StartResourceModel(String configuration, List<Resource> resources, List<String> serviceAccounts, List<String> secrets, List<String> configMaps, List<String> persistenceVolumeClaims) {
+    public StartResourceModel(String configuration, List<Resource> resources, List<String> serviceAccounts, List<String> secrets, List<String> configMaps, List<String> persistentVolumeClaims) {
         this.errorMessage = "Tekton configuration has an invalid format:\n";
         this.inputs = Collections.emptyList();
         this.outputs = Collections.emptyList();
@@ -63,9 +65,14 @@ public class StartResourceModel {
         this.workspaces = Collections.emptyMap();
         this.secrets = secrets;
         this.configMaps = configMaps;
-        this.persistenceVolumeClaims = persistenceVolumeClaims;
+        this.persistenceVolumeClaims = persistentVolumeClaims;
 
         buildModel(configuration);
+    }
+
+    public StartResourceModel(String configuration, List<Resource> resources, List<String> serviceAccounts, List<String> secrets, List<String> configMaps, List<String> persistentVolumeClaims, List<? extends Run> runs) {
+        this(configuration, resources, serviceAccounts, secrets, configMaps, persistentVolumeClaims);
+        this.runs = runs;
     }
 
     private void buildModel(String configuration) {
@@ -314,6 +321,10 @@ public class StartResourceModel {
 
     public List<String> getPersistenceVolumeClaims() {
         return this.persistenceVolumeClaims;
+    }
+
+    public List<? extends Run> getRuns() {
+        return this.runs;
     }
 
     public void adaptsToRun(String configuration) {

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/StartResourceModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/StartResourceModel.java
@@ -18,6 +18,7 @@ import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Output;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Workspace;
 
+import com.redhat.devtools.intellij.tektoncd.utils.model.RunConfigurationModel;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -309,5 +310,41 @@ public class StartResourceModel {
 
     public List<String> getPersistenceVolumeClaims() {
         return this.persistenceVolumeClaims;
+    }
+
+    public void adaptsToRun(String configuration) {
+        // TODO once #187 is merged we will use the factory to get the model
+        RunConfigurationModel conf = new RunConfigurationModel(configuration);
+        /* TODO
+        if (!(conf instanceof RunConfigurationModel)) return;
+         */
+
+        // update params/input resources
+        this.inputs.stream().forEach(input -> {
+            // for each input, update its defaultValue/Value with the value taken from the *run model
+            if (input.kind().equals(Input.Kind.PARAMETER)) {
+                if (conf.getParameters().containsKey(input.name())) {
+                    String value = conf.getParameters().get(input.name());
+                    input.setDefaultValue(value);
+                }
+            } else {
+                String value = conf.getResources().get(input.name());
+                input.setValue(value);
+            }
+        });
+
+        // update workspaces
+        this.workspaces.keySet().forEach(workspaceName -> {
+            this.workspaces.put(workspaceName, conf.getWorkspacesValues().get(workspaceName));
+        });
+
+        //this.serviceAccountName = conf.getServiceAccount();
+
+        /*this.taskServiceAccountNames.keySet().forEach(task -> {
+            if (conf.getTaskServiceAccountNames().has(task)) {
+                this.taskServiceAccountNames.put(task, conf.getTaskServiceAccountNames.get(task));
+            }
+        });*/
+
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/ConfigurationModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/ConfigurationModel.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
 
 public abstract class ConfigurationModel {
     Logger logger = LoggerFactory.getLogger(ConfigurationModel.class);
-    private String namespace, name, kind;
+    protected String namespace, name, kind;
 
     public ConfigurationModel() {
         this.name = "";

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/ConfigurationModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/ConfigurationModel.java
@@ -10,18 +10,10 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.tektoncd.utils.model;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.redhat.devtools.intellij.common.utils.YAMLHelper;
-import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
-import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Output;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-
-import static com.redhat.devtools.intellij.tektoncd.Constants.FLAG_PARAMETER;
 
 public abstract class ConfigurationModel {
     Logger logger = LoggerFactory.getLogger(ConfigurationModel.class);
@@ -55,88 +47,5 @@ public abstract class ConfigurationModel {
 
     public String getNamespace() {
         return namespace;
-    }
-
-    public abstract List<Input> getParams();
-
-    public abstract List<Input> getInputResources();
-
-    public abstract List<Output> getOutputResources();
-
-    public abstract List<String> getWorkspaces();
-
-    protected List<Input> findInputResources(String configuration, String[] fieldNames) {
-        List<Input> inputs = new ArrayList<>();
-
-        try {
-            JsonNode inputsNode = YAMLHelper.getValueFromYAML(configuration, fieldNames);
-            if (inputsNode != null) {
-                inputs.addAll(getInputsFromNode(inputsNode, ""));
-            }
-        } catch (IOException e) {
-            logger.warn(e.getLocalizedMessage());
-        }
-
-        return inputs;
-
-    }
-
-    protected List<Input> findParams(String configuration) {
-        List<Input> inputs = new ArrayList<>();
-
-        try {
-            JsonNode paramsNode = YAMLHelper.getValueFromYAML(configuration, new String[]{"spec", "params"});
-            if (paramsNode != null) {
-                inputs.addAll(getInputsFromNode(paramsNode, FLAG_PARAMETER));
-            }
-        } catch (IOException e) {
-            logger.warn(e.getLocalizedMessage());
-        }
-
-        return inputs;
-
-    }
-
-    protected List<String> findWorkspaces(String configuration) {
-        List<String> workspaces = new ArrayList<>();
-        try {
-            JsonNode workspacesNode = YAMLHelper.getValueFromYAML(configuration, new String[] {"spec", "workspaces"});
-            if (workspacesNode != null) {
-                for(JsonNode item : workspacesNode) {
-                    if (item.has("name")) {
-                        workspaces.add(item.get("name").asText());
-                    }
-                }
-            }
-        } catch (IOException e) {
-            logger.warn(e.getLocalizedMessage());
-        }
-        return workspaces;
-    }
-
-    protected List<Input> getInputsFromNode(JsonNode inputsNode, String flag) {
-        List<Input> result = new ArrayList<>();
-
-        if (flag.equals(FLAG_PARAMETER)) {
-            result.addAll(getInputsFromNodeInternal(inputsNode, Input.Kind.PARAMETER));
-        } else {
-            result.addAll(getInputsFromNodeInternal(inputsNode, Input.Kind.RESOURCE));
-        }
-
-        return result;
-    }
-
-    protected List<Input> getInputsFromNodeInternal(JsonNode node, Input.Kind kind) {
-        List<Input> result = new ArrayList<>();
-        if (node != null) {
-            for (JsonNode item : node) {
-                try {
-                    result.add(new Input().fromJson(item, kind));
-                } catch (Exception e) {
-                    logger.warn(e.getLocalizedMessage());
-                }
-            }
-        }
-        return result;
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/ConfigurationModelFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/ConfigurationModelFactory.java
@@ -12,6 +12,11 @@ package com.redhat.devtools.intellij.tektoncd.utils.model;
 
 import com.google.common.base.Strings;
 import com.redhat.devtools.intellij.common.utils.YAMLHelper;
+import com.redhat.devtools.intellij.tektoncd.utils.model.runs.PipelineRunConfigurationModel;
+import com.redhat.devtools.intellij.tektoncd.utils.model.runs.TaskRunConfigurationModel;
+import com.redhat.devtools.intellij.tektoncd.utils.model.resources.ConditionConfigurationModel;
+import com.redhat.devtools.intellij.tektoncd.utils.model.resources.PipelineConfigurationModel;
+import com.redhat.devtools.intellij.tektoncd.utils.model.resources.TaskConfigurationModel;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +32,8 @@ public class ConfigurationModelFactory {
                     case "pipeline": return new PipelineConfigurationModel(configuration);
                     case "task": return new TaskConfigurationModel(configuration);
                     case "condition": return new ConditionConfigurationModel(configuration);
+                    case "pipelinerun": return new PipelineRunConfigurationModel(configuration);
+                    case "taskrun": return new TaskRunConfigurationModel(configuration);
                     default: break;
                 }
             }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/ResourceConfigurationModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/ResourceConfigurationModel.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.utils.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.redhat.devtools.intellij.common.utils.YAMLHelper;
+import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
+import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Output;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+
+import static com.redhat.devtools.intellij.tektoncd.Constants.FLAG_PARAMETER;
+
+public abstract class ResourceConfigurationModel extends ConfigurationModel {
+
+    public ResourceConfigurationModel(String configuration) {
+        super(configuration);
+    }
+
+    public abstract List<Input> getParams();
+
+    public abstract List<Input> getInputResources();
+
+    public abstract List<Output> getOutputResources();
+
+    public abstract List<String> getWorkspaces();
+
+    protected List<Input> findInputResources(String configuration, String[] fieldNames) {
+        List<Input> inputs = new ArrayList<>();
+
+        try {
+            JsonNode inputsNode = YAMLHelper.getValueFromYAML(configuration, fieldNames);
+            if (inputsNode != null) {
+                inputs.addAll(getInputsFromNode(inputsNode, ""));
+            }
+        } catch (IOException e) {
+            logger.warn(e.getLocalizedMessage());
+        }
+
+        return inputs;
+
+    }
+
+    protected List<Input> findParams(String configuration) {
+        List<Input> inputs = new ArrayList<>();
+
+        try {
+            JsonNode paramsNode = YAMLHelper.getValueFromYAML(configuration, new String[]{"spec", "params"});
+            if (paramsNode != null) {
+                inputs.addAll(getInputsFromNode(paramsNode, FLAG_PARAMETER));
+            }
+        } catch (IOException e) {
+            logger.warn(e.getLocalizedMessage());
+        }
+
+        return inputs;
+
+    }
+
+    protected List<String> findWorkspaces(String configuration) {
+        List<String> workspaces = new ArrayList<>();
+        try {
+            JsonNode workspacesNode = YAMLHelper.getValueFromYAML(configuration, new String[] {"spec", "workspaces"});
+            if (workspacesNode != null) {
+                for(JsonNode item : workspacesNode) {
+                    if (item.has("name")) {
+                        workspaces.add(item.get("name").asText());
+                    }
+                }
+            }
+        } catch (IOException e) {
+            logger.warn(e.getLocalizedMessage());
+        }
+        return workspaces;
+    }
+
+    protected List<Input> getInputsFromNode(JsonNode inputsNode, String flag) {
+        List<Input> result = new ArrayList<>();
+
+        if (flag.equals(FLAG_PARAMETER)) {
+            result.addAll(getInputsFromNodeInternal(inputsNode, Input.Kind.PARAMETER));
+        } else {
+            result.addAll(getInputsFromNodeInternal(inputsNode, Input.Kind.RESOURCE));
+        }
+
+        return result;
+    }
+
+    protected List<Input> getInputsFromNodeInternal(JsonNode node, Input.Kind kind) {
+        List<Input> result = new ArrayList<>();
+        if (node != null) {
+            for (JsonNode item : node) {
+                try {
+                    result.add(new Input().fromJson(item, kind));
+                } catch (Exception e) {
+                    logger.warn(e.getLocalizedMessage());
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/RunConfigurationModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/RunConfigurationModel.java
@@ -1,0 +1,160 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.utils.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.redhat.devtools.intellij.common.utils.YAMLHelper;
+import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
+import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Output;
+import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Workspace;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class RunConfigurationModel extends ConfigurationModel {
+    private String serviceAccountName;
+    private Map<String, String> parameters, inputResources, outputResources, taskServiceAccountNames;
+    private Map<String, Workspace> workspaces;
+
+    public RunConfigurationModel(String configuration) {
+        super(configuration);
+        this.parameters = findParamsValues(configuration);
+        this.taskServiceAccountNames = findServiceAccountNames(configuration);
+
+        this.inputResources = findResourcesValues(configuration);
+        this.workspaces = getWorkspaces(configuration);
+        this.serviceAccountName = findServiceAccountName(configuration);
+    }
+
+    private Map<String, String> findParamsValues(String configuration) {
+        Map<String, String> parameters = new HashMap<>();
+
+        try {
+            JsonNode paramsNode = YAMLHelper.getValueFromYAML(configuration, new String[]{"spec", "params"});
+            if (paramsNode != null) {
+                for (JsonNode item : paramsNode) {
+                    if (!item.has("name") || !item.has("value")) continue;
+                    parameters.put(item.get("name").asText(), item.get("value").asText());
+                }
+            }
+        } catch (IOException e) {
+            logger.warn(e.getLocalizedMessage());
+        }
+
+        return parameters;
+
+    }
+
+    protected Map<String, String> findServiceAccountNames(String configuration) {
+        Map<String, String> taskServiceAccounts = new HashMap<>();
+
+        try {
+            JsonNode serviceAccountsNode = YAMLHelper.getValueFromYAML(configuration, new String[] {"spec", "serviceAccountNames"});
+            if (serviceAccountsNode != null) {
+                for(JsonNode item : serviceAccountsNode) {
+                    if (!item.has("serviceAccountName") || !item.has("taskName"))
+                        continue;
+                    taskServiceAccounts.put(item.get("taskName").asText(), item.get("serviceAccountName").asText());
+                }
+            }
+        } catch (IOException e) {
+            logger.warn(e.getLocalizedMessage());
+        }
+
+        return taskServiceAccounts;
+    }
+
+    protected String findServiceAccountName(String configuration) {
+        try {
+            return YAMLHelper.getStringValueFromYAML(configuration, new String[] {"spec", "serviceAccountName"});
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    protected Map<String, String> findResourcesValues(String configuration) {
+        Map<String, String> resources = new HashMap<>();
+
+        try {
+            JsonNode paramsNode = YAMLHelper.getValueFromYAML(configuration, new String[]{"spec", "resources"});
+            if (paramsNode != null) {
+                for (JsonNode item : paramsNode) {
+                    if (!item.has("name") || !item.has("resourceRef") ) continue;
+                    resources.put(item.get("name").asText(), item.get("value").asText());
+                }
+            }
+        } catch (IOException e) {
+            logger.warn(e.getLocalizedMessage());
+        }
+
+        return resources;
+    }
+
+    private Map<String, Workspace> getWorkspaces(String configuration) {
+        Map<String, Workspace> workspaces = new HashMap<>();
+        try {
+            JsonNode workspacesNode = YAMLHelper.getValueFromYAML(configuration, new String[] {"spec", "workspaces"});
+            if (workspacesNode != null) {
+                for(JsonNode item : workspacesNode) {
+                    if (!item.has("name")) continue;
+                    String name = item.get("name").asText();
+                    Workspace.Kind kind = item.has("persistentVolumeClaim") ? Workspace.Kind.PVC :
+                                          item.has("configMap") ? Workspace.Kind.CONFIGMAP :
+                                          item.has("secret") ? Workspace.Kind.SECRET :
+                                          Workspace.Kind.EMPTYDIR;
+                    String resource = kind.equals(Workspace.Kind.PVC) ? item.get("persistentVolumeClaim").get("claimName").asText() :
+                                      kind.equals(Workspace.Kind.CONFIGMAP) ? item.get("configMap").get("name").asText() :
+                                      kind.equals(Workspace.Kind.SECRET) ? item.get("secret").get("secretName").asText() :
+                                        null;
+                    workspaces.put(name, new Workspace(name, kind, resource));
+                }
+            }
+        } catch (IOException e) {
+            logger.warn(e.getLocalizedMessage());
+        }
+        return workspaces;
+    }
+
+    public Map<String, String> getParameters() {
+        return this.parameters;
+    }
+
+    public Map<String, String> getResources() {
+        return this.inputResources;
+    }
+
+    public Map<String, Workspace> getWorkspacesValues() {
+        return this.workspaces;
+    }
+
+    @Override
+    public List<Input> getParams() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Input> getInputResources() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Output> getOutputResources() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<String> getWorkspaces() {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/RunConfigurationModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/RunConfigurationModel.java
@@ -12,26 +12,20 @@ package com.redhat.devtools.intellij.tektoncd.utils.model;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.redhat.devtools.intellij.common.utils.YAMLHelper;
-import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
-import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Output;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Workspace;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-public class RunConfigurationModel extends ConfigurationModel {
+public abstract class RunConfigurationModel extends ConfigurationModel {
     private String serviceAccountName;
-    private Map<String, String> parameters, inputResources, outputResources, taskServiceAccountNames;
+    private Map<String, String> parameters, taskServiceAccountNames;
     private Map<String, Workspace> workspaces;
 
     public RunConfigurationModel(String configuration) {
         super(configuration);
         this.parameters = findParamsValues(configuration);
         this.taskServiceAccountNames = findServiceAccountNames(configuration);
-
-        this.inputResources = findResourcesValues(configuration);
         this.workspaces = getWorkspaces(configuration);
         this.serviceAccountName = findServiceAccountName(configuration);
     }
@@ -83,15 +77,15 @@ public class RunConfigurationModel extends ConfigurationModel {
         return null;
     }
 
-    protected Map<String, String> findResourcesValues(String configuration) {
+    protected Map<String, String> findResources(String configuration, String[] fields) {
         Map<String, String> resources = new HashMap<>();
 
         try {
-            JsonNode paramsNode = YAMLHelper.getValueFromYAML(configuration, new String[]{"spec", "resources"});
+            JsonNode paramsNode = YAMLHelper.getValueFromYAML(configuration, fields);
             if (paramsNode != null) {
                 for (JsonNode item : paramsNode) {
                     if (!item.has("name") || !item.has("resourceRef") ) continue;
-                    resources.put(item.get("name").asText(), item.get("value").asText());
+                    resources.put(item.get("name").asText(), item.get("resourceRef").get("name").asText());
                 }
             }
         } catch (IOException e) {
@@ -130,31 +124,15 @@ public class RunConfigurationModel extends ConfigurationModel {
         return this.parameters;
     }
 
-    public Map<String, String> getResources() {
-        return this.inputResources;
-    }
-
     public Map<String, Workspace> getWorkspacesValues() {
         return this.workspaces;
     }
 
-    @Override
-    public List<Input> getParams() {
-        return Collections.emptyList();
+    public String getServiceAccountName() {
+        return this.serviceAccountName;
     }
 
-    @Override
-    public List<Input> getInputResources() {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public List<Output> getOutputResources() {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public List<String> getWorkspaces() {
-        return Collections.emptyList();
+    public Map<String, String> getTaskServiceAccountNames() {
+        return this.taskServiceAccountNames;
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/resources/ConditionConfigurationModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/resources/ConditionConfigurationModel.java
@@ -8,23 +8,22 @@
  * Contributors:
  * Red Hat, Inc.
  ******************************************************************************/
-package com.redhat.devtools.intellij.tektoncd.utils.model;
+package com.redhat.devtools.intellij.tektoncd.utils.model.resources;
 
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Output;
+import com.redhat.devtools.intellij.tektoncd.utils.model.ResourceConfigurationModel;
 import java.util.Collections;
 import java.util.List;
 
-public class PipelineConfigurationModel extends ConfigurationModel {
+public class ConditionConfigurationModel extends ResourceConfigurationModel {
     private List<Input> params;
     private List<Input> inputResource;
-    private List<String> workspaces;
 
-    public PipelineConfigurationModel(String configuration) {
+    public ConditionConfigurationModel(String configuration) {
         super(configuration);
         this.params = findParams(configuration);
         this.inputResource = findInputResources(configuration, new String[] {"spec", "resources"});
-        this.workspaces = findWorkspaces(configuration);
     }
 
     @Override
@@ -44,6 +43,6 @@ public class PipelineConfigurationModel extends ConfigurationModel {
 
     @Override
     public List<String> getWorkspaces() {
-        return this.workspaces;
+        return Collections.emptyList();
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/resources/PipelineConfigurationModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/resources/PipelineConfigurationModel.java
@@ -8,21 +8,24 @@
  * Contributors:
  * Red Hat, Inc.
  ******************************************************************************/
-package com.redhat.devtools.intellij.tektoncd.utils.model;
+package com.redhat.devtools.intellij.tektoncd.utils.model.resources;
 
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Output;
+import com.redhat.devtools.intellij.tektoncd.utils.model.ResourceConfigurationModel;
 import java.util.Collections;
 import java.util.List;
 
-public class ConditionConfigurationModel extends ConfigurationModel {
+public class PipelineConfigurationModel extends ResourceConfigurationModel {
     private List<Input> params;
     private List<Input> inputResource;
+    private List<String> workspaces;
 
-    public ConditionConfigurationModel(String configuration) {
+    public PipelineConfigurationModel(String configuration) {
         super(configuration);
         this.params = findParams(configuration);
         this.inputResource = findInputResources(configuration, new String[] {"spec", "resources"});
+        this.workspaces = findWorkspaces(configuration);
     }
 
     @Override
@@ -42,6 +45,6 @@ public class ConditionConfigurationModel extends ConfigurationModel {
 
     @Override
     public List<String> getWorkspaces() {
-        return Collections.emptyList();
+        return this.workspaces;
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/resources/TaskConfigurationModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/resources/TaskConfigurationModel.java
@@ -8,19 +8,20 @@
  * Contributors:
  * Red Hat, Inc.
  ******************************************************************************/
-package com.redhat.devtools.intellij.tektoncd.utils.model;
+package com.redhat.devtools.intellij.tektoncd.utils.model.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.redhat.devtools.intellij.common.utils.YAMLHelper;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Output;
+import com.redhat.devtools.intellij.tektoncd.utils.model.ResourceConfigurationModel;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TaskConfigurationModel extends ConfigurationModel {
+public class TaskConfigurationModel extends ResourceConfigurationModel {
     Logger logger = LoggerFactory.getLogger(TaskConfigurationModel.class);
     private List<Input> params;
     private List<Input> inputResources;

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/runs/PipelineRunConfigurationModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/runs/PipelineRunConfigurationModel.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.utils.model.runs;
+
+import com.redhat.devtools.intellij.tektoncd.utils.model.RunConfigurationModel;
+import java.util.Map;
+
+public class PipelineRunConfigurationModel extends RunConfigurationModel {
+    private Map<String, String> resources;
+
+    public PipelineRunConfigurationModel(String configuration) {
+        super(configuration);
+        this.resources = findResources(configuration, new String[]{"spec", "resources"});
+    }
+
+    public Map<String, String> getResources() {
+        return this.resources;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/runs/TaskRunConfigurationModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/runs/TaskRunConfigurationModel.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.utils.model.runs;
+
+import com.redhat.devtools.intellij.tektoncd.utils.model.RunConfigurationModel;
+import java.util.Map;
+
+public class TaskRunConfigurationModel extends RunConfigurationModel {
+    private Map<String, String> inputResources, outputResources;
+
+    public TaskRunConfigurationModel(String configuration) {
+        super(configuration);
+        this.inputResources = findResources(configuration, new String[]{"spec", "resources", "inputs"});
+        this.outputResources = findResources(configuration, new String[]{"spec", "resources", "outputs"});
+    }
+
+    public Map<String, String> getInputResources() {
+        return this.inputResources;
+    }
+
+    public Map<String, String> getOutputResources() {
+        return this.outputResources;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -61,7 +61,7 @@
       <action class="com.redhat.devtools.intellij.tektoncd.actions.triggers.CreateEventListenerAction" text="New Event Listener"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.OpenEditorAction" text="Open in Editor"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.StartAction" text="Start"/>
-      <action class="com.redhat.devtools.intellij.tektoncd.actions.StartMirrorRunAction" text="Start Mirror Run"/>
+      <action class="com.redhat.devtools.intellij.tektoncd.actions.MirrorStartAction" text="Mirror Start"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.StartLastRunAction" text="Start Last Run"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.logs.FollowLogsAction" text="Follow Logs"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.logs.ShowLogsAction" text="Show Logs"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -61,6 +61,7 @@
       <action class="com.redhat.devtools.intellij.tektoncd.actions.triggers.CreateEventListenerAction" text="New Event Listener"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.OpenEditorAction" text="Open in Editor"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.StartAction" text="Start"/>
+      <action class="com.redhat.devtools.intellij.tektoncd.actions.StartMirrorRunAction" text="Start Mirror Run"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.StartLastRunAction" text="Start Last Run"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.logs.FollowLogsAction" text="Follow Logs"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.logs.ShowLogsAction" text="Show Logs"/>

--- a/src/test/java/com/redhat/devtools/intellij/tektoncd/utils/model/ConditionConfigurationModelTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/tektoncd/utils/model/ConditionConfigurationModelTest.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.intellij.tektoncd.utils.model;
 
 import com.redhat.devtools.intellij.tektoncd.BaseTest;
+import com.redhat.devtools.intellij.tektoncd.utils.model.resources.ConditionConfigurationModel;
 import java.io.IOException;
 import org.junit.Test;
 

--- a/src/test/java/com/redhat/devtools/intellij/tektoncd/utils/model/ConfigurationModelFactoryTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/tektoncd/utils/model/ConfigurationModelFactoryTest.java
@@ -11,6 +11,9 @@
 package com.redhat.devtools.intellij.tektoncd.utils.model;
 
 import com.redhat.devtools.intellij.tektoncd.BaseTest;
+import com.redhat.devtools.intellij.tektoncd.utils.model.resources.ConditionConfigurationModel;
+import com.redhat.devtools.intellij.tektoncd.utils.model.resources.PipelineConfigurationModel;
+import com.redhat.devtools.intellij.tektoncd.utils.model.resources.TaskConfigurationModel;
 import java.io.IOException;
 import org.junit.Test;
 

--- a/src/test/java/com/redhat/devtools/intellij/tektoncd/utils/model/PipelineConfigurationModelTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/tektoncd/utils/model/PipelineConfigurationModelTest.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.intellij.tektoncd.utils.model;
 
 import com.redhat.devtools.intellij.tektoncd.BaseTest;
+import com.redhat.devtools.intellij.tektoncd.utils.model.resources.PipelineConfigurationModel;
 import java.io.IOException;
 import org.junit.Test;
 

--- a/src/test/java/com/redhat/devtools/intellij/tektoncd/utils/model/TaskConfigurationModelTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/tektoncd/utils/model/TaskConfigurationModelTest.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.intellij.tektoncd.utils.model;
 
 import com.redhat.devtools.intellij.tektoncd.BaseTest;
+import com.redhat.devtools.intellij.tektoncd.utils.model.resources.TaskConfigurationModel;
 import java.io.IOException;
 import org.junit.Test;
 


### PR DESCRIPTION
it resolves #161 

This PR allows users to open the start wizard with data taken from an old *run in two ways

1) A new action belonging to a *run node. It opens up the wizard with data taken from the *run selected. 
If the original pipeline has been updated with new fields, only the ones existing in the *run will be filled in.
If the pipeline has been updated and some fields have been removed, only the ones existing in the pipeline/*run will be filled in.

I called the action `start mirror` but i am not really sure about the naming. Any better idea?
![image](https://user-images.githubusercontent.com/49404737/92389673-d0561400-f119-11ea-99ec-bbcea3e75d5a.png)

2) The wizard has a new panel (advanced options) which contains an option to take data from a specific *run.
Once a *run is selected in the combobox, the wizard is updated with the values taken from that *run.

The options panel is quite empty now but all options related to the start action will be added here.

![image](https://user-images.githubusercontent.com/49404737/92390481-368f6680-f11b-11ea-9c8c-0cc2c7c21ac4.png)

![image](https://user-images.githubusercontent.com/49404737/92390518-4c9d2700-f11b-11ea-889b-be26b4bf8407.png)

![image](https://user-images.githubusercontent.com/49404737/92390216-bcf77880-f11a-11ea-90cf-8419bca97594.png)


