### PR TITLE
switched back to 0.11.0

### DIFF
--- a/src/main/resources/tkn.json
+++ b/src/main/resources/tkn.json
@@ -1,29 +1,28 @@
 {
   "tools": {
     "tkn": {
-      "version": "0.12.0",
+      "version": "0.11.0",
       "versionCmd": "version",
       "versionExtractRegExp": "Client version: (\\d+[\\.\\d+]*)\\s.*",
       "versionMatchRegExpr": "0\\..*",
       "baseDir": "$HOME/.tekton",
       "platforms": {
         "win": {
-          "url": "https://github.com/tektoncd/cli/releases/download/v0.12.0/tkn_0.12.0_Windows_x86_64.zip",
+          "url": "https://github.com/tektoncd/cli/releases/download/v0.11.0/tkn_0.11.0_Windows_x86_64.zip",
           "cmdFileName": "tkn.exe",
-          "dlFileName": "tkn_0.12.0_Windows_x86_64.zip"
+          "dlFileName": "tkn_0.11.0_Windows_x86_64.zip"
         },
         "osx": {
-          "url": "https://github.com/tektoncd/cli/releases/download/v0.12.0/tkn_0.12.0_Darwin_x86_64.tar.gz",
+          "url": "https://github.com/tektoncd/cli/releases/download/v0.11.0/tkn_0.11.0_Darwin_x86_64.tar.gz",
           "cmdFileName": "tkn",
-          "dlFileName": "tkn_0.12.0_Darwin_x86_64.tar.gz"
+          "dlFileName": "tkn_0.11.0_Darwin_x86_64.tar.gz"
         },
         "lnx": {
-          "url": "https://github.com/tektoncd/cli/releases/download/v0.12.0/tkn_0.12.0_Linux_x86_64.tar.gz",
+          "url": "https://github.com/tektoncd/cli/releases/download/v0.11.0/tkn_0.11.0_Linux_x86_64.tar.gz",
           "cmdFileName": "tkn",
-          "dlFileName": "tkn_0.12.0_Linux_x86_64.tar.gz"
+          "dlFileName": "tkn_0.11.0_Linux_x86_64.tar.gz"
         }
       }
     }
   }
 }
-


### PR DESCRIPTION
Due to a performance issue with tkn cli 0.12.0, this patch switch the cli used by the plugin back to 0.11.0.

By testing again with the old cli, you can really see the difference in speed.