### PR TITLE
Action to take infos regarding resources created by a run

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/ShowDiagnosticDataAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/ShowDiagnosticDataAction.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.redhat.devtools.intellij.common.utils.ExecHelper;
+import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
+import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
+import com.redhat.devtools.intellij.tektoncd.tree.PipelineRunNode;
+import com.redhat.devtools.intellij.tektoncd.tree.TaskRunNode;
+import javax.swing.tree.TreePath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ShowDiagnosticDataAction extends TektonAction {
+    Logger logger = LoggerFactory.getLogger(ShowDiagnosticDataAction.class);
+
+    public ShowDiagnosticDataAction() { super(PipelineRunNode.class, TaskRunNode.class); }
+
+    @Override
+    public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Tkn tkncli) {
+        ExecHelper.submit(() -> {
+            ParentableNode element = getElement(selected);
+            String namespace = element.getNamespace();
+            if (element instanceof PipelineRunNode) {
+                tkncli.getDiagnosticData(namespace, "tekton.dev/pipelineRun", element.getName());
+            } else if (element instanceof TaskRunNode) {
+                tkncli.getDiagnosticData(namespace, "tekton.dev/taskRun", element.getName());
+            }
+        });
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/ShowDiagnosticDataAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/ShowDiagnosticDataAction.java
@@ -33,11 +33,18 @@ public class ShowDiagnosticDataAction extends TektonAction {
         ExecHelper.submit(() -> {
             ParentableNode element = getElement(selected);
             String namespace = element.getNamespace();
+            boolean hasDataToShow = false;
             try {
                 if (element instanceof PipelineRunNode) {
-                    tkncli.getDiagnosticData(namespace, "tekton.dev/pipelineRun", element.getName());
+                    hasDataToShow = tkncli.getDiagnosticData(namespace, "tekton.dev/pipelineRun", element.getName());
                 } else if (element instanceof TaskRunNode) {
-                    tkncli.getDiagnosticData(namespace, "tekton.dev/taskRun", element.getName());
+                    hasDataToShow = tkncli.getDiagnosticData(namespace, "tekton.dev/taskRun", element.getName());
+                }
+                if (!hasDataToShow) {
+                    UIHelper.executeInUI(() ->
+                            Messages.showWarningDialog(
+                                    "No data available for " + element.getName() + " in namespace " + namespace + ".",
+                                    "Diagnostic Data"));
                 }
             } catch (IOException e) {
                 UIHelper.executeInUI(() ->

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/Tkn.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/Tkn.java
@@ -594,7 +594,16 @@ public interface Tkn {
      */
     Watch watchConditions(String namespace, Watcher<io.fabric8.tekton.pipeline.v1alpha1.Condition> watcher) throws IOException;
 
-    void getDiagnosticData(String namespace, String keyLabel, String valueLabel) throws IOException;
+    /**
+     * Get diagnostic data related to objects with the field=value pair
+     *
+     * @param namespace the namespace to use
+     * @param keyLabel the key to use to retrieve the objects
+     * @param valueLabel the value to use to retrieve the objects
+     * @return if the search succeeded or not
+     * @throws IOException if communication errored
+     */
+    boolean getDiagnosticData(String namespace, String keyLabel, String valueLabel) throws IOException;
 
     public URL getMasterUrl();
 

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/Tkn.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/Tkn.java
@@ -594,7 +594,7 @@ public interface Tkn {
      */
     Watch watchConditions(String namespace, Watcher<io.fabric8.tekton.pipeline.v1alpha1.Condition> watcher) throws IOException;
 
-    void getDiagnosticData(String namespace, String keyLabel, String valueLabel);
+    void getDiagnosticData(String namespace, String keyLabel, String valueLabel) throws IOException;
 
     public URL getMasterUrl();
 

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/Tkn.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/Tkn.java
@@ -594,6 +594,8 @@ public interface Tkn {
      */
     Watch watchConditions(String namespace, Watcher<io.fabric8.tekton.pipeline.v1alpha1.Condition> watcher) throws IOException;
 
+    void getDiagnosticData(String namespace, String keyLabel, String valueLabel);
+
     public URL getMasterUrl();
 
     public <T> T getClient(Class<T> clazz);

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCli.java
@@ -13,20 +13,25 @@ package com.redhat.devtools.intellij.tektoncd.tkn;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.intellij.common.utils.ExecHelper;
 import com.redhat.devtools.intellij.common.utils.NetworkUtils;
 import com.redhat.devtools.intellij.tektoncd.Constants;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Workspace;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodCondition;
 import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetCondition;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetList;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.tekton.client.TektonClient;
@@ -556,15 +561,36 @@ public class TknCli implements Tkn {
     }
 
     @Override
-    public void getDiagnosticData(String namespace, String keyLabel, String valueLabel) {
+    public void getDiagnosticData(String namespace, String keyLabel, String valueLabel) throws IOException {
+        String data = "";
         PodList pods = client.pods().inNamespace(namespace).withLabel(keyLabel, valueLabel).list();
-        pods.getItems().forEach(pod -> {
-            PodResource p = client.pods().inNamespace(namespace).withName(pod.getMetadata().getName());
-            Pod p1 = (Pod) p.get();
-            p1.getStatus().getConditions();
-        });
-        //client.pods().inNamespace(namespace).withName("").
-        //ExecHelper.executeWithTerminal(project, Constants.TERMINAL_TITLE, false, envVars, command, "pipelinerun", "logs", pipelineRun, "-n", namespace);
+        for (Pod pod: pods.getItems()) {
+            PodStatus podStatus = pod.getStatus();
+            data += getFormattedWarningMessage(podStatus.getReason(), podStatus.getMessage());
+            for (PodCondition podCondition : podStatus.getConditions()) {
+                data += getFormattedWarningMessage(podCondition.getReason(), podCondition.getMessage());
+            }
+        }
+        StatefulSetList states = client.apps().statefulSets().inNamespace(namespace).withLabel(keyLabel, valueLabel).list();
+        for (StatefulSet state: states.getItems()) {
+            for (StatefulSetCondition stateCondition : state.getStatus().getConditions()) {
+                data += getFormattedWarningMessage(stateCondition.getReason(), stateCondition.getMessage());
+            }
+        }
+
+        ExecHelper.executeWithTerminal(project, Constants.TERMINAL_TITLE, false, envVars, "echo", "-e", data);
+
+    }
+
+    private String getFormattedWarningMessage(String reason, String message) {
+        String data = "";
+        if (!Strings.isNullOrEmpty(reason)) {
+            data = "reason: " + reason;
+        }
+        if (!Strings.isNullOrEmpty(message)) {
+            data = "message:" + message;
+        }
+        return data + "\n";
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCli.java
@@ -18,12 +18,15 @@ import com.redhat.devtools.intellij.common.utils.ExecHelper;
 import com.redhat.devtools.intellij.common.utils.NetworkUtils;
 import com.redhat.devtools.intellij.tektoncd.Constants;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Workspace;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.tekton.client.TektonClient;
@@ -550,6 +553,18 @@ public class TknCli implements Tkn {
         } catch (KubernetesClientException e) {
             throw new IOException(e);
         }
+    }
+
+    @Override
+    public void getDiagnosticData(String namespace, String keyLabel, String valueLabel) {
+        PodList pods = client.pods().inNamespace(namespace).withLabel(keyLabel, valueLabel).list();
+        pods.getItems().forEach(pod -> {
+            PodResource p = client.pods().inNamespace(namespace).withName(pod.getMetadata().getName());
+            Pod p1 = (Pod) p.get();
+            p1.getStatus().getConditions();
+        });
+        //client.pods().inNamespace(namespace).withName("").
+        //ExecHelper.executeWithTerminal(project, Constants.TERMINAL_TITLE, false, envVars, command, "pipelinerun", "logs", pipelineRun, "-n", namespace);
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCli.java
@@ -561,7 +561,7 @@ public class TknCli implements Tkn {
     }
 
     @Override
-    public void getDiagnosticData(String namespace, String keyLabel, String valueLabel) throws IOException {
+    public boolean getDiagnosticData(String namespace, String keyLabel, String valueLabel) throws IOException {
         String data = "";
         PodList pods = client.pods().inNamespace(namespace).withLabel(keyLabel, valueLabel).list();
         for (Pod pod: pods.getItems()) {
@@ -578,8 +578,16 @@ public class TknCli implements Tkn {
             }
         }
 
-        ExecHelper.executeWithTerminal(project, Constants.TERMINAL_TITLE, false, envVars, "echo", "-e", data);
+        if (data.isEmpty()) {
+            return false;
+        }
 
+        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+            ExecHelper.executeWithTerminal(project, Constants.TERMINAL_TITLE, false, envVars, "cmd.exe", "/C", "echo", "-e", data);
+        } else {
+            ExecHelper.executeWithTerminal(project, Constants.TERMINAL_TITLE, false, envVars, "echo", "-e", data);
+        }
+        return true;
     }
 
     private String getFormattedWarningMessage(String reason, String message) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -84,6 +84,7 @@
       <action class="com.redhat.devtools.intellij.tektoncd.actions.StartLastRunAction" text="Start Last Run"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.logs.FollowLogsAction" text="Follow Logs"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.logs.ShowLogsAction" text="Show Logs"/>
+      <action class="com.redhat.devtools.intellij.tektoncd.actions.ShowDiagnosticDataAction" text="Show Diagnostic Data"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.CancelAction" text="Cancel"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.DeleteAction" text="Delete"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.RefreshAction" text="Refresh"/>


### PR DESCRIPTION
It resolves #181 

This is the a very basic implementation of an action which should be useful to debug a *run. 
As an example, i created a pvc with a size which wasn't supported by my cluster (there was no pv available for that size) and so the *run could not be completed but it was stuck in a running mode. 
By using the tkn cli the user doesn't receive any feedback in such cases.
By clicking on the `Show Diagnostic Data` action this is the result. 
![image](https://user-images.githubusercontent.com/49404737/93781956-42eee580-fc2a-11ea-81c1-4dd34274fd94.png)

I'll try to add more examples as soon as i find them. Any other suggestion for this? @jeffmaury 
