### PR TITLE
PipelineRun diagram preview retrieve Pipeline defintion if not embedd…

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/editors/PipelineRunGraphUpdater.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/editors/PipelineRunGraphUpdater.java
@@ -36,18 +36,17 @@ public class PipelineRunGraphUpdater extends AbstractPipelineGraphUpdater<Pipeli
 
     @Override
     public void update(PipelineRun content, mxGraph graph) {
-        if (content.getStatus() != null) {
-            if (content.getSpec().getPipelineSpec() != null) {
-                update(content, content.getStatus().getPipelineSpec(), graph);
-            } else if (content.getSpec().getPipelineRef() != null && StringUtils.isNotBlank(content.getSpec().getPipelineRef().getName())) {
-                TknCliFactory.getInstance().getTkn(null).thenAcceptAsync(tkn -> {
-                    try {
-                        String pipelineYAML = tkn.getPipelineYAML(content.getMetadata().getNamespace(), content.getSpec().getPipelineRef().getName());
-                        Pipeline pipeline = MAPPER.readValue(pipelineYAML, Pipeline.class);
-                        update(content, pipeline.getSpec(), graph);
-                    } catch (IOException e) {}
-                });
-            }
+        if (content.getStatus() != null && content.getStatus().getPipelineSpec() != null) {
+            update(content, content.getStatus().getPipelineSpec(), graph);
+        } else if (content.getSpec() != null && content.getSpec().getPipelineRef() != null && StringUtils.isNotBlank(content.getSpec().getPipelineRef().getName())) {
+            TknCliFactory.getInstance().getTkn(null).thenAcceptAsync(tkn -> {
+                try {
+                    String pipelineYAML = tkn.getPipelineYAML(content.getMetadata().getNamespace(), content.getSpec().getPipelineRef().getName());
+                    Pipeline pipeline = MAPPER.readValue(pipelineYAML, Pipeline.class);
+                    update(content, pipeline.getSpec(), graph);
+                } catch (IOException e) {
+                }
+            });
         }
     }
 


### PR DESCRIPTION
…ed in PipelineRun

Fixes #237

Signed-off-by: Jeff MAURY <jmaury@redhat.com>

WARNING: in order to test it, you must use OpenShift Pipelines that does not embed Pipeline definition in PipelineRun or use an older Tekton Pipelines (but I don't know which version)