### PR TITLE
Grey unused variables

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/component/field/Input.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/component/field/Input.java
@@ -63,6 +63,10 @@ public class Input {
     }
 
     public Input fromJson(JsonNode inputNode, Kind kind) {
+        if (!inputNode.has("name") ||
+                inputNode.get("name").isNull()) {
+            return null;
+        }
         String name = inputNode.get("name").asText();
         String type = "string";
         Optional<String> description = Optional.empty();

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/component/field/Output.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/component/field/Output.java
@@ -47,7 +47,11 @@ public class Output {
     }
 
     public Output fromJson(JsonNode outputNode) {
-        String name = outputNode.get("name").asText();
+        if (!outputNode.has("name") ||
+                outputNode.get("name").isNull()) {
+            return null;
+        }
+        String name = outputNode.get("name").asText("");
         String type = "string"; // which is default value for a resource ??
         Optional<String> description = Optional.empty();
         Optional<Boolean> optional = Optional.empty();

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/TektonReferencesInspection.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/TektonReferencesInspection.java
@@ -1,0 +1,166 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.utils;
+
+import com.intellij.codeInspection.InspectionManager;
+import com.intellij.codeInspection.LocalInspectionTool;
+import com.intellij.codeInspection.LocalQuickFix;
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.lang.FileASTNode;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
+import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Output;
+import com.redhat.devtools.intellij.tektoncd.utils.model.ConfigurationModel;
+import com.redhat.devtools.intellij.tektoncd.utils.model.ConfigurationModelFactory;
+import com.redhat.devtools.intellij.tektoncd.utils.model.resources.PipelineConfigurationModel;
+import com.redhat.devtools.intellij.tektoncd.utils.model.resources.TaskConfigurationModel;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+
+import static com.redhat.devtools.intellij.common.CommonConstants.PROJECT;
+
+public class TektonReferencesInspection extends LocalInspectionTool {
+
+    @Nullable
+    @Override
+    public ProblemDescriptor[] checkFile(@NotNull PsiFile file, @NotNull InspectionManager manager, boolean isOnTheFly) {
+        if (!file.getLanguage().getID().equalsIgnoreCase("yaml")) {
+            return ProblemDescriptor.EMPTY_ARRAY;
+        }
+
+        final VirtualFile virtualFile = file.getVirtualFile();
+        final Project project = virtualFile.getUserData(PROJECT);
+        if (project == null) {
+            return ProblemDescriptor.EMPTY_ARRAY;
+        }
+        ConfigurationModel model = ConfigurationModelFactory.getModel(file.getText());
+        if (model == null) {
+            return ProblemDescriptor.EMPTY_ARRAY;
+        }
+
+        List<PsiElement> unusedPsiElements = new ArrayList<>();
+        if (model instanceof PipelineConfigurationModel) {
+            unusedPsiElements = highlightInPipeline(file, (PipelineConfigurationModel) model);
+        } else if (model instanceof TaskConfigurationModel) {
+            unusedPsiElements = highlightInTask(file, (TaskConfigurationModel) model);
+        }
+
+        return unusedPsiElements.stream().map(item ->
+                manager.createProblemDescriptor(item, item, "Variable " + item.getText() + " is never used", ProblemHighlightType.LIKE_UNUSED_SYMBOL, isOnTheFly, LocalQuickFix.EMPTY_ARRAY)
+        ).toArray(ProblemDescriptor[]::new);
+    }
+
+    private List<PsiElement> highlightInPipeline(PsiFile file, PipelineConfigurationModel model) {
+        List<Input> params = model.getParams();
+        List<Input> inputResources = model.getInputResources();
+        List<String> workspaces = model.getWorkspaces();
+
+        if (params.isEmpty() && inputResources.isEmpty() && workspaces.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return findUnusedVariables(file, params, inputResources, Collections.emptyList(), workspaces);
+    }
+
+    private List<PsiElement> highlightInTask(PsiFile file, TaskConfigurationModel model) {
+        List<Input> params = model.getParams();
+        List<Input> inputResources = model.getInputResources();
+        List<Output> outputResources = model.getOutputResources();
+        List<String> workspaces = model.getWorkspaces();
+
+        if (params.isEmpty() && inputResources.isEmpty() && outputResources.isEmpty() && workspaces.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return findUnusedVariables(file, params, inputResources, outputResources, workspaces);
+    }
+
+    private List<PsiElement> findUnusedVariables(PsiFile file, List<Input> params, List<Input> inputResource, List<Output> outputResources, List<String> workspaces) {
+        if (!file.getText().contains("\nspec:")) {
+            return Collections.emptyList();
+        }
+
+        String spec = file.getText().substring(file.getText().indexOf("\nspec:"));
+        List<PsiElement> unusedPsiElements = new ArrayList<>();
+
+        params.forEach(param -> {
+            int variableFirstUsageIndex = indexOfByPattern(Pattern.compile("\\$\\(params\\." + param.name()), spec);
+            if (variableFirstUsageIndex == -1) {
+                PsiElement psiNode = getVariablePsiElement(file, "params:", param.name());
+                unusedPsiElements.add(psiNode);
+            }
+        });
+
+        inputResource.forEach(resource -> {
+            int variableFirstUsageIndex = indexOfByPattern(Pattern.compile("\\$\\(resources\\.inputs\\." + resource.name()), spec);
+            if (variableFirstUsageIndex == -1) {
+                PsiElement psiNode;
+                if (isPipeline(file)) {
+                    psiNode = getVariablePsiElement(file, "resources:", resource.name());
+                } else {
+                    psiNode = getVariablePsiElement(file, "inputs:", resource.name());
+                }
+                unusedPsiElements.add(psiNode);
+            }
+        });
+
+        outputResources.forEach(resource -> {
+            int variableFirstUsageIndex = indexOfByPattern(Pattern.compile("\\$\\(resources\\.outputs\\." + resource.name()), spec);
+            if (variableFirstUsageIndex == -1) {
+                PsiElement psiNode = getVariablePsiElement(file, "outputs:", resource.name());
+                unusedPsiElements.add(psiNode);
+            }
+        });
+
+        workspaces.forEach(workspace -> {
+            int variableFirstUsageIndex = indexOfByPattern(Pattern.compile("\\$\\(workspaces\\." + workspace), spec);
+            if (variableFirstUsageIndex == -1) {
+                PsiElement psiNode = getVariablePsiElement(file, "workspaces:", workspace);
+                unusedPsiElements.add(psiNode);
+            }
+        });
+
+        return unusedPsiElements;
+    }
+
+    private PsiElement getVariablePsiElement(PsiFile file, String inputType, String variable) {
+        int specIndex = file.getText().indexOf("\nspec:");
+        String spec = file.getText().substring(specIndex);
+        final FileASTNode node = file.getNode();
+        int variableTypeIndex = spec.indexOf(inputType);
+        String variableTypeSection = spec.substring(variableTypeIndex);
+        int variableLineIndex = indexOfByPattern(Pattern.compile("name:\\s*" + variable), variableTypeSection);
+        int actualVariableIndex = variableTypeSection.substring(variableLineIndex).indexOf(variable);
+        int absoluteIndex = specIndex + variableTypeIndex + variableLineIndex + actualVariableIndex;
+        PsiElement psiNode = node.findLeafElementAt(absoluteIndex).getPsi();
+        return psiNode;
+    }
+
+    private boolean isPipeline(PsiFile file) {
+        int pipelineIndex = indexOfByPattern(Pattern.compile("kind:\\s*Pipeline"), file.getText());
+        return pipelineIndex != -1;
+    }
+
+    private int indexOfByPattern(Pattern pattern, String textWhereToSearch) {
+        Matcher matcher = pattern.matcher(textWhereToSearch);
+        return matcher.find() ? matcher.start() : -1;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/VariableReferencesInspector.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/VariableReferencesInspector.java
@@ -10,9 +10,6 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.tektoncd.utils;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.intellij.codeInspection.InspectionManager;
 import com.intellij.codeInspection.LocalInspectionTool;
 import com.intellij.codeInspection.LocalQuickFix;
@@ -20,20 +17,14 @@ import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.lang.ASTNode;
 import com.intellij.lang.FileASTNode;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiFile;
-import com.intellij.psi.PsiRecursiveElementWalkingVisitor;
-import com.redhat.devtools.intellij.common.utils.YAMLHelper;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Output;
 import com.redhat.devtools.intellij.tektoncd.utils.model.ConfigurationModel;
 import com.redhat.devtools.intellij.tektoncd.utils.model.ConfigurationModelFactory;
 import com.redhat.devtools.intellij.tektoncd.utils.model.resources.PipelineConfigurationModel;
 import com.redhat.devtools.intellij.tektoncd.utils.model.resources.TaskConfigurationModel;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -41,11 +32,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.yaml.parser.YAMLParser;
-import org.jetbrains.yaml.psi.YamlPsiElementVisitor;
-
-
-import static com.redhat.devtools.intellij.common.CommonConstants.PROJECT;
 
 public class VariableReferencesInspector extends LocalInspectionTool {
 
@@ -56,11 +42,6 @@ public class VariableReferencesInspector extends LocalInspectionTool {
             return ProblemDescriptor.EMPTY_ARRAY;
         }
 
-        final VirtualFile virtualFile = file.getVirtualFile();
-        final Project project = virtualFile.getUserData(PROJECT);
-        if (project == null) {
-            return ProblemDescriptor.EMPTY_ARRAY;
-        }
         ConfigurationModel model = ConfigurationModelFactory.getModel(file.getText());
         if (model == null) {
             return ProblemDescriptor.EMPTY_ARRAY;

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/VariableReferencesInspector.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/VariableReferencesInspector.java
@@ -10,22 +10,30 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.tektoncd.utils;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.intellij.codeInspection.InspectionManager;
 import com.intellij.codeInspection.LocalInspectionTool;
 import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.lang.ASTNode;
 import com.intellij.lang.FileASTNode;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiRecursiveElementWalkingVisitor;
+import com.redhat.devtools.intellij.common.utils.YAMLHelper;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Output;
 import com.redhat.devtools.intellij.tektoncd.utils.model.ConfigurationModel;
 import com.redhat.devtools.intellij.tektoncd.utils.model.ConfigurationModelFactory;
 import com.redhat.devtools.intellij.tektoncd.utils.model.resources.PipelineConfigurationModel;
 import com.redhat.devtools.intellij.tektoncd.utils.model.resources.TaskConfigurationModel;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -33,11 +41,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.yaml.parser.YAMLParser;
+import org.jetbrains.yaml.psi.YamlPsiElementVisitor;
 
 
 import static com.redhat.devtools.intellij.common.CommonConstants.PROJECT;
 
-public class TektonReferencesInspection extends LocalInspectionTool {
+public class VariableReferencesInspector extends LocalInspectionTool {
 
     @Nullable
     @Override
@@ -102,39 +112,49 @@ public class TektonReferencesInspection extends LocalInspectionTool {
         List<PsiElement> unusedPsiElements = new ArrayList<>();
 
         params.forEach(param -> {
-            int variableFirstUsageIndex = indexOfByPattern(Pattern.compile("\\$\\(params\\." + param.name()), spec);
-            if (variableFirstUsageIndex == -1) {
+            List<Integer> variableUsageIndexes = indexesOfByPattern(Pattern.compile("\\$\\(params\\." + param.name()), spec);
+            if (variableUsageIndexes.isEmpty()) {
                 PsiElement psiNode = getVariablePsiElement(file, "params:", param.name());
-                unusedPsiElements.add(psiNode);
+                if (psiNode != null) {
+                    unusedPsiElements.add(psiNode);
+                }
             }
         });
 
         inputResource.forEach(resource -> {
-            int variableFirstUsageIndex = indexOfByPattern(Pattern.compile("\\$\\(resources\\.inputs\\." + resource.name()), spec);
-            if (variableFirstUsageIndex == -1) {
+            Pattern pattern = isPipeline(file) ? Pattern.compile("resource:\\s+" + resource.name()) : Pattern.compile("\\$\\(resources\\.inputs\\." + resource.name());
+            List<Integer> variableUsageIndexes = indexesOfByPattern(pattern, spec);
+            if (variableUsageIndexes.isEmpty()) {
                 PsiElement psiNode;
                 if (isPipeline(file)) {
                     psiNode = getVariablePsiElement(file, "resources:", resource.name());
                 } else {
                     psiNode = getVariablePsiElement(file, "inputs:", resource.name());
                 }
-                unusedPsiElements.add(psiNode);
+                if (psiNode != null) {
+                    unusedPsiElements.add(psiNode);
+                }
             }
         });
 
         outputResources.forEach(resource -> {
-            int variableFirstUsageIndex = indexOfByPattern(Pattern.compile("\\$\\(resources\\.outputs\\." + resource.name()), spec);
-            if (variableFirstUsageIndex == -1) {
+            List<Integer> variableUsageIndexes = indexesOfByPattern(Pattern.compile("\\$\\(resources\\.outputs\\." + resource.name()), spec);
+            if (variableUsageIndexes.isEmpty()) {
                 PsiElement psiNode = getVariablePsiElement(file, "outputs:", resource.name());
-                unusedPsiElements.add(psiNode);
+                if (psiNode != null) {
+                    unusedPsiElements.add(psiNode);
+                }
             }
         });
 
         workspaces.forEach(workspace -> {
-            int variableFirstUsageIndex = indexOfByPattern(Pattern.compile("\\$\\(workspaces\\." + workspace), spec);
-            if (variableFirstUsageIndex == -1) {
+            Pattern pattern = isPipeline(file) ? Pattern.compile("workspace:\\s+" + workspace) : Pattern.compile("\\$\\(workspaces\\." + workspace);
+            List<Integer> variableUsageIndexes = indexesOfByPattern(pattern, spec);
+            if (variableUsageIndexes.isEmpty()) {
                 PsiElement psiNode = getVariablePsiElement(file, "workspaces:", workspace);
-                unusedPsiElements.add(psiNode);
+                if (psiNode != null) {
+                    unusedPsiElements.add(psiNode);
+                }
             }
         });
 
@@ -145,22 +165,54 @@ public class TektonReferencesInspection extends LocalInspectionTool {
         int specIndex = file.getText().indexOf("\nspec:");
         String spec = file.getText().substring(specIndex);
         final FileASTNode node = file.getNode();
-        int variableTypeIndex = spec.indexOf(inputType);
+        // it needs to find the correct section index. it may happen there are two section with the same name. e.g workspaces as direct spec child or taskRef child
+        List<Integer> inputTypeIndexes = indexesOfByPattern(Pattern.compile(inputType), spec);
+        int variableTypeIndex = getActualTypeSectionIndex(file, inputTypeIndexes);
+        if (variableTypeIndex == -1) {
+            return null;
+        }
+
         String variableTypeSection = spec.substring(variableTypeIndex);
-        int variableLineIndex = indexOfByPattern(Pattern.compile("name:\\s*" + variable), variableTypeSection);
-        int actualVariableIndex = variableTypeSection.substring(variableLineIndex).indexOf(variable);
-        int absoluteIndex = specIndex + variableTypeIndex + variableLineIndex + actualVariableIndex;
+        List<Integer> variableLineIndex = indexesOfByPattern(Pattern.compile("name:\\s*" + variable), variableTypeSection);
+        if (variableLineIndex.isEmpty()) {
+            return null;
+        }
+        int actualVariableIndex = variableTypeSection.substring(variableLineIndex.get(0)).indexOf(variable);
+        int absoluteIndex = specIndex + variableTypeIndex + variableLineIndex.get(0) + actualVariableIndex;
         PsiElement psiNode = node.findLeafElementAt(absoluteIndex).getPsi();
         return psiNode;
     }
 
-    private boolean isPipeline(PsiFile file) {
-        int pipelineIndex = indexOfByPattern(Pattern.compile("kind:\\s*Pipeline"), file.getText());
-        return pipelineIndex != -1;
+    private int getActualTypeSectionIndex(PsiFile file, List<Integer> indexes) {
+        int index = -1;
+        int specIndex = file.getText().indexOf("\nspec:");
+        FileASTNode node = file.getNode();
+        for (int tmpIndex: indexes) {
+            ASTNode psiNode = node.findLeafElementAt(specIndex + tmpIndex);
+            if (isSpecDirectChild(psiNode)) {
+                index = tmpIndex;
+                break;
+            }
+        }
+        return index;
     }
 
-    private int indexOfByPattern(Pattern pattern, String textWhereToSearch) {
+    private boolean isSpecDirectChild(ASTNode node) {
+        return node.getTreeParent().getTreeParent().getTreeParent().getText().startsWith("spec:") ||
+                node.getTreeParent().getTreeParent().getTreeParent().getFirstChildNode().getText().startsWith("resources");
+    }
+
+    private boolean isPipeline(PsiFile file) {
+        List<Integer> pipelineIndex = indexesOfByPattern(Pattern.compile("kind:\\s*Pipeline"), file.getText());
+        return !pipelineIndex.isEmpty();
+    }
+
+    private List<Integer> indexesOfByPattern(Pattern pattern, String textWhereToSearch) {
+        List<Integer> indexes = new ArrayList<>();
         Matcher matcher = pattern.matcher(textWhereToSearch);
-        return matcher.find() ? matcher.start() : -1;
+        while (matcher.find()) {
+            indexes.add(matcher.start());
+        }
+        return indexes;
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/ResourceConfigurationModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/ResourceConfigurationModel.java
@@ -101,7 +101,10 @@ public abstract class ResourceConfigurationModel extends ConfigurationModel {
         if (node != null) {
             for (JsonNode item : node) {
                 try {
-                    result.add(new Input().fromJson(item, kind));
+                    Input i = new Input().fromJson(item, kind);
+                    if (i != null) {
+                        result.add(i);
+                    }
                 } catch (Exception e) {
                     logger.warn(e.getLocalizedMessage());
                 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/resources/TaskConfigurationModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/resources/TaskConfigurationModel.java
@@ -54,7 +54,10 @@ public class TaskConfigurationModel extends ResourceConfigurationModel {
 
         if (outputsNode != null) {
             for (JsonNode item : outputsNode) {
-                result.add(new Output().fromJson(item));
+                Output o = new Output().fromJson(item);
+                if (o != null) {
+                    result.add(o);
+                }
             }
         }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -79,14 +79,9 @@
     <completion.contributor language="any" implementationClass="com.redhat.devtools.intellij.tektoncd.completion.DictionaryContributor"/>
     <toolWindow id="Tekton" anchor="left" factoryClass="com.redhat.devtools.intellij.tektoncd.WindowToolFactory" icon="/images/cluster.png"/>
     <fileEditorProvider implementation="com.redhat.devtools.intellij.tektoncd.ui.editors.TektonFileEditorProvider"/>
-    <localInspection language="yaml"
-                     displayName="SDK: '==' or '!=' used instead of 'equals()'"
-                     groupPath="Java"
-                     groupBundle="messages.InspectionsBundle"
-                     groupKey="group.names.probable.bugs"
-                     enabledByDefault="true"
-                     level="WARNING"
-                     implementationClass="com.redhat.devtools.intellij.tektoncd.utils.TektonReferencesInspection"/>
+    <localInspection language="yaml" bundle="messages.YAMLBundle" displayName="Tekton Unused Variable inspector"
+                     level="WARNING" groupKey="inspections.group.name" enabledByDefault="true"
+                     implementationClass="com.redhat.devtools.intellij.tektoncd.utils.VariableReferencesInspector"/>
   </extensions>
   <actions>
     <group id="com.redhat.devtools.intellij.tektoncd.tree" popup="true">

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -79,6 +79,14 @@
     <completion.contributor language="any" implementationClass="com.redhat.devtools.intellij.tektoncd.completion.DictionaryContributor"/>
     <toolWindow id="Tekton" anchor="left" factoryClass="com.redhat.devtools.intellij.tektoncd.WindowToolFactory" icon="/images/cluster.png"/>
     <fileEditorProvider implementation="com.redhat.devtools.intellij.tektoncd.ui.editors.TektonFileEditorProvider"/>
+    <localInspection language="yaml"
+                     displayName="SDK: '==' or '!=' used instead of 'equals()'"
+                     groupPath="Java"
+                     groupBundle="messages.InspectionsBundle"
+                     groupKey="group.names.probable.bugs"
+                     enabledByDefault="true"
+                     level="WARNING"
+                     implementationClass="com.redhat.devtools.intellij.tektoncd.utils.TektonReferencesInspection"/>
   </extensions>
   <actions>
     <group id="com.redhat.devtools.intellij.tektoncd.tree" popup="true">

--- a/src/test/java/com/redhat/devtools/intellij/tektoncd/utils/VariableReferenceInspectorTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/tektoncd/utils/VariableReferenceInspectorTest.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.utils;
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfo;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess;
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture;
+import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
+import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory;
+import com.intellij.testFramework.fixtures.TestFixtureBuilder;
+import com.redhat.devtools.intellij.tektoncd.BaseTest;
+import java.io.File;
+import java.util.List;
+import org.jetbrains.yaml.schema.YamlJsonSchemaHighlightingInspection;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class VariableReferenceInspectorTest {
+
+    private CodeInsightTestFixture myFixture;
+
+    @Before
+    public void setup() throws Exception {
+        IdeaTestFixtureFactory factory = IdeaTestFixtureFactory.getFixtureFactory();
+        TestFixtureBuilder<IdeaProjectTestFixture> fixtureBuilder = factory.createLightFixtureBuilder(null);
+        IdeaProjectTestFixture fixture = fixtureBuilder.getFixture();
+
+        myFixture = IdeaTestFixtureFactory.getFixtureFactory().createCodeInsightFixture(fixture, factory.createTempDirTestFixture());
+
+        myFixture.setTestDataPath("src/test/resources/utils/variableReferenceInspector/");
+        myFixture.setUp();
+        myFixture.enableInspections(VariableReferencesInspector.class);
+        VfsRootAccess.allowRootAccess(new File("src").getAbsoluteFile().getParentFile().getAbsolutePath());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        myFixture.tearDown();
+    }
+
+    @Test
+    public void testPipelineHighlightWithUnusedParameter() {
+        myFixture.configureByFile("pipeline1.yaml");
+        List<HighlightInfo> hightlightInfo =  myFixture.doHighlighting();
+        assertEquals(hightlightInfo.size(), 1);
+        assertTrue(hightlightInfo.get(0).getDescription().equals("Variable p1 is never used"));
+    }
+
+    @Test
+    public void testPipelineHighlightWithUnusedResource() {
+        myFixture.configureByFile("pipeline2.yaml");
+        List<HighlightInfo> hightlightInfo =  myFixture.doHighlighting();
+        assertEquals(hightlightInfo.size(), 2);
+        assertTrue(hightlightInfo.get(0).getDescription().equals("Variable source-repo is never used"));
+        assertTrue(hightlightInfo.get(1).getDescription().equals("Variable web-image is never used"));
+    }
+
+    @Test
+    public void testPipelineHighlightWithUnusedWorkspace() {
+        myFixture.configureByFile("pipeline3.yaml");
+        List<HighlightInfo> hightlightInfo =  myFixture.doHighlighting();
+        assertEquals(hightlightInfo.size(), 1);
+        assertTrue(hightlightInfo.get(0).getDescription().equals("Variable password-vault is never used"));
+    }
+
+    @Test
+    public void testPipelineHighlightWithUnusedVariables() {
+        myFixture.configureByFile("pipeline4.yaml");
+        List<HighlightInfo> hightlightInfo =  myFixture.doHighlighting();
+        assertEquals(hightlightInfo.size(), 3);
+        assertTrue(hightlightInfo.get(0).getDescription().equals("Variable p1 is never used"));
+        assertTrue(hightlightInfo.get(1).getDescription().equals("Variable source-repo is never used"));
+        assertTrue(hightlightInfo.get(2).getDescription().equals("Variable password-vault is never used"));
+    }
+
+    @Test
+    public void testTaskHighlightWithUnusedParameter() {
+        myFixture.configureByFile("task1.yaml");
+        List<HighlightInfo> hightlightInfo =  myFixture.doHighlighting();
+        assertEquals(hightlightInfo.size(), 1);
+        assertTrue(hightlightInfo.get(0).getDescription().equals("Variable parm1 is never used"));
+    }
+
+    @Test
+    public void testTaskHighlightWithUnusedInputResource() {
+        myFixture.configureByFile("task2.yaml");
+        List<HighlightInfo> hightlightInfo =  myFixture.doHighlighting();
+        assertEquals(hightlightInfo.size(), 1);
+        assertTrue(hightlightInfo.get(0).getDescription().equals("Variable resource1 is never used"));
+    }
+
+    @Test
+    public void testTaskHighlightWithUnusedOutputResource() {
+        myFixture.configureByFile("task3.yaml");
+        List<HighlightInfo> hightlightInfo =  myFixture.doHighlighting();
+        assertEquals(hightlightInfo.size(), 1);
+        assertTrue(hightlightInfo.get(0).getDescription().equals("Variable resource1 is never used"));
+    }
+
+    @Test
+    public void testTaskHighlightWithUnusedWorkspace() {
+        myFixture.configureByFile("task4.yaml");
+        List<HighlightInfo> hightlightInfo =  myFixture.doHighlighting();
+        assertEquals(hightlightInfo.size(), 2);
+        assertTrue(hightlightInfo.get(0).getDescription().equals("Variable write-allowed is never used"));
+        assertTrue(hightlightInfo.get(1).getDescription().equals("Variable write-disallowed is never used"));
+    }
+
+    @Test
+    public void testTaskHighlightWithUnusedVariables() {
+        myFixture.configureByFile("task5.yaml");
+        List<HighlightInfo> hightlightInfo =  myFixture.doHighlighting();
+        assertEquals(hightlightInfo.size(), 4);
+        assertTrue(hightlightInfo.get(0).getDescription().equals("Variable write-allowed is never used"));
+        assertTrue(hightlightInfo.get(1).getDescription().equals("Variable parm1 is never used"));
+        assertTrue(hightlightInfo.get(2).getDescription().equals("Variable resource2 is never used"));
+        assertTrue(hightlightInfo.get(3).getDescription().equals("Variable resource1 is never used"));
+
+    }
+
+}

--- a/src/test/resources/utils/variableReferenceInspector/pipeline1.yaml
+++ b/src/test/resources/utils/variableReferenceInspector/pipeline1.yaml
@@ -1,0 +1,13 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: app-deploy
+spec:
+  params:
+    - name: p1
+      default: [value1,value2]
+  tasks:
+    - name: foo
+      taskRef:
+        kind: Task
+        name: foo

--- a/src/test/resources/utils/variableReferenceInspector/pipeline2.yaml
+++ b/src/test/resources/utils/variableReferenceInspector/pipeline2.yaml
@@ -1,0 +1,17 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: app-deploy
+spec:
+  resources:
+    - name: source-repo
+      type: git
+      optional: true
+    - name: web-image
+      type: image
+      optional: true
+  tasks:
+    - name: foo
+      taskRef:
+        kind: Task
+        name: foo

--- a/src/test/resources/utils/variableReferenceInspector/pipeline3.yaml
+++ b/src/test/resources/utils/variableReferenceInspector/pipeline3.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: app-deploy
+spec:
+  workspaces:
+    - name: password-vault
+  tasks:
+    - name: foo
+      taskRef:
+        kind: Task
+        name: foo

--- a/src/test/resources/utils/variableReferenceInspector/pipeline4.yaml
+++ b/src/test/resources/utils/variableReferenceInspector/pipeline4.yaml
@@ -1,0 +1,18 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: app-deploy
+spec:
+  params:
+    - name: p1
+      default: value1
+  resources:
+    - name: source-repo
+      type: git
+  workspaces:
+    - name: password-vault
+  tasks:
+    - name: foo
+      taskRef:
+        kind: Task
+        name: foo

--- a/src/test/resources/utils/variableReferenceInspector/task1.yaml
+++ b/src/test/resources/utils/variableReferenceInspector/task1.yaml
@@ -1,0 +1,18 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: foo
+  namespace: tekton
+spec:
+  params:
+    - name: parm1
+      type: string
+  steps:
+    - args:
+        - -c
+        - echo hello world
+      command:
+        - /bin/bash
+      image: fedora
+      name: build-sources
+      resources: {}

--- a/src/test/resources/utils/variableReferenceInspector/task2.yaml
+++ b/src/test/resources/utils/variableReferenceInspector/task2.yaml
@@ -1,0 +1,19 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: foo
+  namespace: tekton
+spec:
+  resources:
+    inputs:
+      - name: resource1
+        type: image
+  steps:
+    - args:
+        - -c
+        - echo hello world
+      command:
+        - /bin/bash
+      image: fedora
+      name: build-sources
+      resources: {}

--- a/src/test/resources/utils/variableReferenceInspector/task3.yaml
+++ b/src/test/resources/utils/variableReferenceInspector/task3.yaml
@@ -1,0 +1,19 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: foo
+  namespace: tekton
+spec:
+  resources:
+    outputs:
+      - name: resource1
+        type: image
+  steps:
+    - args:
+        - -c
+        - echo hello world
+      command:
+        - /bin/bash
+      image: fedora
+      name: build-sources
+      resources: {}

--- a/src/test/resources/utils/variableReferenceInspector/task4.yaml
+++ b/src/test/resources/utils/variableReferenceInspector/task4.yaml
@@ -1,0 +1,19 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: foo
+  namespace: tekton
+spec:
+  workspaces:
+    - name: write-allowed
+    - name: write-disallowed
+      readOnly: true
+  steps:
+    - args:
+        - -c
+        - echo hello world
+      command:
+        - /bin/bash
+      image: fedora
+      name: build-sources
+      resources: {}

--- a/src/test/resources/utils/variableReferenceInspector/task5.yaml
+++ b/src/test/resources/utils/variableReferenceInspector/task5.yaml
@@ -1,0 +1,27 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: foo
+  namespace: tekton
+spec:
+  workspaces:
+    - name: write-allowed
+  params:
+    - name: parm1
+      type: string
+  resources:
+    inputs:
+      - name: resource2
+        type: git
+    outputs:
+      - name: resource1
+        type: image
+  steps:
+    - args:
+        - -c
+        - echo hello world
+      command:
+        - /bin/bash
+      image: fedora
+      name: build-sources
+      resources: {}


### PR DESCRIPTION
it resolves #182 

This patch makes all unused variables being colored in gray so users can easily see if they have some variables that can be removed or that has to be used somewhere. Useful when you copy a pipeline/task from internet/TektonHub and start editing it based on your requirement.

![unusedvariables](https://user-images.githubusercontent.com/49404737/97724544-56188f00-1acd-11eb-8bee-9ba915545ca8.gif)
