### PR TITLE
Add generated CRDs for better compatibility with IntelliJ Kubernetes …

### DIFF
--- a/.github/workflows/IJ.yml
+++ b/.github/workflows/IJ.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        IJ: [IC-2019.2, IC-2019.3, IC-2020.1, IC-2020.2]
+        IJ: [IU-2019.2, IU-2019.3, IU-2020.1, IU-2020.2]
 
     steps:
     - uses: actions/checkout@v2

--- a/build.gradle
+++ b/build.gradle
@@ -16,11 +16,12 @@ repositories {
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 
+def versionsMap = ['IU-2019.2':'192.5728.98','IU-2019.3':'193.5233.144','IU-2020.1':'201.6668.99', 'IU-2020.2':'202.6397.93']
 
 intellij {
     version ideaVersion //for a full list of IntelliJ IDEA releases please see https://www.jetbrains.com/intellij-repository/releases
     pluginName 'com.redhat.devtools.intellij.tekton'
-    plugins 'terminal', 'yaml'
+    plugins 'terminal', 'yaml', 'com.intellij.kubernetes:' + versionsMap[ideaVersion]
     updateSinceUntilBuild false
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-ideaVersion = IC-2019.2
+ideaVersion = IU-2019.2
 projectVersion=0.3.0-SNAPSHOT
 jetBrainsToken=invalid
 jetBrainsChannel=stable

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/kubernetes/TektonHighlightInfoFilter.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/kubernetes/TektonHighlightInfoFilter.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.kubernetes;
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfo;
+import com.intellij.codeInsight.daemon.impl.HighlightInfoFilter;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.intellij.tektoncd.validation.KubernetesTypeInfo;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.regex.Pattern;
+
+public class TektonHighlightInfoFilter implements HighlightInfoFilter {
+    /*
+     * as there is no way to find the originating plugin from an highlight info, we are looking at the
+     * tooltip that relates to the inspection tool that generated it.
+     */
+    private static final Pattern TOOLTIP_REGEXP = Pattern.compile(".*href=\"#inspection\\/Kubernetes.*\".*");
+
+    @Override
+    public boolean accept(@NotNull HighlightInfo highlightInfo, @Nullable PsiFile file) {
+        return !isKubernetesHighlight(highlightInfo) || !isTektonFile(file);
+    }
+
+    private boolean isTektonFile(PsiFile file) {
+        KubernetesTypeInfo info = KubernetesTypeInfo.extractMeta(file);
+        return info.getApiGroup().startsWith("tekton.dev") || info.getApiGroup().startsWith("trigger.tekton.dev");
+    }
+
+    private boolean isKubernetesHighlight(HighlightInfo highlightInfo) {
+        return TOOLTIP_REGEXP.matcher(highlightInfo.getToolTip()).matches();
+    }
+}

--- a/src/main/resources/META-INF/plugin-kubernetes.xml
+++ b/src/main/resources/META-INF/plugin-kubernetes.xml
@@ -1,0 +1,5 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <daemon.highlightInfoFilter implementation="com.redhat.devtools.intellij.tektoncd.kubernetes.TektonHighlightInfoFilter"/>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -72,6 +72,7 @@
   <depends>org.jetbrains.plugins.terminal</depends>
   <depends>org.jetbrains.plugins.yaml</depends>
   <depends optional="true" config-file="plugin-json.xml">com.intellij.modules.json</depends>
+  <depends optional="true" config-file="plugin-kubernetes.xml">com.intellij.kubernetes</depends>
 
   <extensions defaultExtensionNs="com.intellij">
     <!-- Add your extensions here -->


### PR DESCRIPTION
…plugin

- K8S metadata specified as object thus annotations and labels are reported as errors
- Some time related fields are not propertly handled
- tkn cli removes the version info for Triggers resources

Fixes #263

Signed-off-by: Jeff MAURY <jmaury@redhat.com>

**WARNING**

In order to test it, you need to change **ideaVersion** in _gradle.properties_ from IC-XXXX to IU-XXXX as the IntelliJ Kubernetes plugin is compatible with IU only