### PR TITLE
Refresh node before expanding (#275)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/listener/TreeExpansionListener.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/listener/TreeExpansionListener.java
@@ -10,8 +10,11 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.tektoncd.listener;
 
+import com.intellij.ui.treeStructure.Tree;
 import com.redhat.devtools.intellij.common.actions.StructureTreeAction;
+import com.redhat.devtools.intellij.tektoncd.Constants;
 import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
+import com.redhat.devtools.intellij.tektoncd.tree.TektonTreeStructure;
 import com.redhat.devtools.intellij.tektoncd.utils.WatchHandler;
 
 import javax.swing.event.TreeExpansionEvent;
@@ -23,6 +26,7 @@ public class TreeExpansionListener implements TreeWillExpandListener {
         ParentableNode<? extends ParentableNode<?>> expandingElement = StructureTreeAction.getElement(treeExpansionEvent.getPath().getLastPathComponent());
         if (WatchHandler.get().canBeWatched(expandingElement)) {
             WatchHandler.get().setWatchByNode(expandingElement, treeExpansionEvent.getPath());
+            ((TektonTreeStructure)((Tree)treeExpansionEvent.getSource()).getClientProperty(Constants.STRUCTURE_PROPERTY)).fireModified(expandingElement);
         }
     }
 


### PR DESCRIPTION
it resolves #275 

The problem here is that the watch is set when a node is actually expanded but its children were already calculated and the user see an old version of them.


E.g in a tree like
```
root
|->namespace
          |-> pipelines
                     |-> pipeline-1
                     |-> pipeline-2
```
when the tree is created it contains `root`, `namespace` and `pipelines` nodes, with `pipelines` node hidden. When `namespace` is expanded, `pipelines` is made visible and `pipeline-1` and `pipeline-2` are pre-loaded (they are hidden). At this point if something change on cluster (e.g `pipeline-3` is created), the children of pipelines are not updated as this was not expanded and the watch has not been activated.

This is a quick fix. As soon as we start depending on the k8s plugin and we show only the current active namespace we can switch at having the watch set up at node creation and keep it always alive 