### PR TITLE
Generate taskrun example from task (#289)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/Constants.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/Constants.java
@@ -43,10 +43,10 @@ public class Constants {
     public static final String KIND_CLUSTERTRIGGERBINDING = "clustertriggerbinding";
     public static final String KIND_EVENTLISTENER = "eventlistener";
 
-    public static final String KIND_PVC =  "PersistentVolumeClaim";
-    public static final String KIND_CONFIGMAP =  "ConfigMap";
-    public static final String KIND_SECRET =  "Secret";
-    public static final String KIND_EMPTYDIR =  "EmptyDir";
+    public static final String KIND_PVC = "persistentVolumeClaim";
+    public static final String KIND_CONFIGMAP = "configMap";
+    public static final String KIND_SECRET = "secret";
+    public static final String KIND_EMPTYDIR =  "emptyDir";
 
     public static final String FLAG_SERVICEACCOUNT = "-s";
     public static final String FLAG_TASKSERVICEACCOUNT = "--task-serviceaccount";

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/AddTriggerAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/AddTriggerAction.java
@@ -134,7 +134,7 @@ public class AddTriggerAction extends TektonAction {
                    String triggerTemplateName = element.getName() + "-template-" + randomString;
                    ObjectNode run;
                    if (element instanceof PipelineNode) {
-                       run = YAMLBuilder.createPipelineRun(element.getName(), model);
+                       run = YAMLBuilder.createPipelineRun(model);
                    } else {
                        run = YAMLBuilder.createTaskRun(model);
                    }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/AddTriggerAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/AddTriggerAction.java
@@ -136,7 +136,7 @@ public class AddTriggerAction extends TektonAction {
                    if (element instanceof PipelineNode) {
                        run = YAMLBuilder.createPipelineRun(element.getName(), model);
                    } else {
-                       run = YAMLBuilder.createTaskRun(element.getName(), model);
+                       run = YAMLBuilder.createTaskRun(model);
                    }
                    ObjectNode triggerTemplate = YAMLBuilder.createTriggerTemplate(triggerTemplateName, new ArrayList<>(paramsFromBindings), Arrays.asList(run));
                    saveResource(YAMLBuilder.writeValueAsString(triggerTemplate), namespace, "triggertemplates", tkncli);

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/task/CreateTaskRunTemplateAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/task/CreateTaskRunTemplateAction.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.actions.task;
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.ui.Messages;
+import com.redhat.devtools.intellij.common.utils.ExecHelper;
+import com.redhat.devtools.intellij.common.utils.UIHelper;
+import com.redhat.devtools.intellij.tektoncd.actions.TektonAction;
+import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
+import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
+import com.redhat.devtools.intellij.tektoncd.tree.TaskNode;
+import com.redhat.devtools.intellij.tektoncd.utils.VirtualFileHelper;
+import com.redhat.devtools.intellij.tektoncd.utils.YAMLBuilder;
+import com.redhat.devtools.intellij.tektoncd.utils.model.resources.TaskConfigurationModel;
+import java.io.IOException;
+import javax.swing.tree.TreePath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_TASKRUN;
+import static com.redhat.devtools.intellij.tektoncd.Constants.NOTIFICATION_ID;
+
+public class CreateTaskRunTemplateAction extends TektonAction {
+
+    private static final Logger logger = LoggerFactory.getLogger(CreateTaskRunTemplateAction.class);
+
+    public CreateTaskRunTemplateAction() { super(TaskNode.class); }
+
+    @Override
+    public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Tkn tkncli) {
+        ParentableNode element = getElement(selected);
+        String namespace = element.getNamespace();
+        ExecHelper.submit(() -> {
+            Notification notification;
+            TaskConfigurationModel model;
+            try {
+                model = getModel(element, namespace, tkncli);
+            } catch (IOException e) {
+                UIHelper.executeInUI(() ->
+                        Messages.showErrorDialog(
+                                "Failed to create TaskRun templace from " + element.getName() + " in namespace " + namespace + "An error occurred while retrieving information.\n" + e.getLocalizedMessage(),
+                                "Error"));
+                logger.warn("Error: " + e.getLocalizedMessage());
+                return;
+            }
+
+            if (!model.isValid()) {
+                UIHelper.executeInUI(() -> Messages.showErrorDialog("Failed to create a TaskRun templace from " + element.getName() + " in namespace " + namespace + ". The task is not valid.", "Error"));
+                return;
+            }
+
+            try {
+                String contentTask = new YAMLMapper().writeValueAsString(YAMLBuilder.createTaskRun(model));
+                UIHelper.executeInUI(() ->
+                        VirtualFileHelper.openVirtualFileInEditor(anActionEvent.getProject(), namespace, "generate-taskrun-" + model.getName(), contentTask, KIND_TASKRUN, true));
+            } catch (IOException e) {
+                notification = new Notification(NOTIFICATION_ID,
+                        "Error",
+                        "Failed to create TaskRun templace from" + element.getName() + " in namespace " + namespace + " \n" + e.getLocalizedMessage(),
+                        NotificationType.ERROR);
+                Notifications.Bus.notify(notification);
+                logger.warn("Error: " + e.getLocalizedMessage());
+            }
+
+        });
+    }
+
+    protected TaskConfigurationModel getModel(ParentableNode element, String namespace, Tkn tkncli) throws IOException {
+        String configuration = "";
+        if (element instanceof TaskNode) {
+            configuration = tkncli.getTaskYAML(namespace, element.getName());
+        }
+        return new TaskConfigurationModel(configuration);
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/BaseWizard.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/BaseWizard.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.tektoncd.ui.wizard;
 
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.intellij.CommonBundle;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.ide.IdeBundle;
@@ -467,10 +468,11 @@ public abstract class BaseWizard extends DialogWrapper {
         }
     }
 
+
     protected void updatePreview(ActionToRunModel model) {
         String preview = "";
         try {
-            preview = YAMLBuilder.createPreview(model);
+            preview = new YAMLMapper().writeValueAsString(YAMLBuilder.createTaskRun(model)); //.createPreview(model);
         } catch (IOException e) {
             //logger.warn("Error: " + e.getLocalizedMessage());
         }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/BaseWizard.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/BaseWizard.java
@@ -472,7 +472,7 @@ public abstract class BaseWizard extends DialogWrapper {
     protected void updatePreview(ActionToRunModel model) {
         String preview = "";
         try {
-            preview = new YAMLMapper().writeValueAsString(YAMLBuilder.createTaskRun(model)); //.createPreview(model);
+            preview = new YAMLMapper().writeValueAsString(YAMLBuilder.createRun(model));
         } catch (IOException e) {
             //logger.warn("Error: " + e.getLocalizedMessage());
         }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/CRDHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/CRDHelper.java
@@ -18,6 +18,8 @@ import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_CLUSTERTASK;
 import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_CLUSTERTASKS;
 import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_CLUSTERTRIGGERBINDING;
 import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_CLUSTERTRIGGERBINDINGS;
+import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_PIPELINERUN;
+import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_TASKRUN;
 
 public class CRDHelper {
     public static CustomResourceDefinitionContext getCRDContext(String apiVersion, String plural) {
@@ -38,6 +40,10 @@ public class CRDHelper {
     }
 
     public static boolean isClusterScopedResource(String kind) {
-        return kind == KIND_CLUSTERTASKS || kind == KIND_CLUSTERTASK || kind == KIND_CLUSTERTRIGGERBINDING || kind == KIND_CLUSTERTRIGGERBINDINGS;
+        return kind.equalsIgnoreCase(KIND_CLUSTERTASKS) || kind.equalsIgnoreCase(KIND_CLUSTERTASK) || kind.equalsIgnoreCase(KIND_CLUSTERTRIGGERBINDING) || kind.equalsIgnoreCase(KIND_CLUSTERTRIGGERBINDINGS);
+    }
+
+    public static boolean isRunResource(String kind) {
+        return kind.equalsIgnoreCase(KIND_PIPELINERUN) || kind.equalsIgnoreCase(KIND_TASKRUN);
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/TreeHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/TreeHelper.java
@@ -158,7 +158,7 @@ public class TreeHelper {
         if (yamlAndKind != null && !yamlAndKind.getFirst().isEmpty()) {
             Project project = element.getRoot().getProject();
             String namespace = element.getNamespace();
-            VirtualFileHelper.openVirtualFileInEditor(project, namespace, element.getName(), yamlAndKind.getFirst(), yamlAndKind.getSecond());
+            VirtualFileHelper.openVirtualFileInEditor(project, namespace, element.getName(), yamlAndKind.getFirst(), yamlAndKind.getSecond(), false);
         }
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/VirtualFileHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/VirtualFileHelper.java
@@ -28,22 +28,26 @@ import static com.redhat.devtools.intellij.tektoncd.Constants.TARGET_NODE;
 public class VirtualFileHelper {
     static Logger logger = LoggerFactory.getLogger(VirtualFileHelper.class);
 
-    public static void openVirtualFileInEditor(Project project, String namespace, String name, String content, String kind) {
+    public static void openVirtualFileInEditor(Project project, String namespace, String name, String content, String kind, boolean forceWritable) {
         Optional<FileEditor> editor = Arrays.stream(FileEditorManager.getInstance(project).getAllEditors()).
                 filter(fileEditor -> fileEditor.getFile().getName().startsWith(namespace + "-" + name + ".yaml")).findFirst();
         if (!editor.isPresent()) {
-            VirtualFileHelper.createAndOpenVirtualFile(project, namespace, namespace + "-" + name + ".yaml", content, kind, null);
+            VirtualFileHelper.createAndOpenVirtualFile(project, namespace, namespace + "-" + name + ".yaml", content, kind, null, forceWritable);
         } else {
             FileEditorManager.getInstance(project).openTextEditor(new OpenFileDescriptor(project, editor.get().getFile()), true);
         }
     }
 
     public static void createAndOpenVirtualFile(Project project, String namespace, String name, String content, String kind, ParentableNode<?> targetNode) {
+        createAndOpenVirtualFile(project, namespace, name, content, kind, targetNode, false);
+    }
+
+    public static void  createAndOpenVirtualFile(Project project, String namespace, String name, String content, String kind, ParentableNode<?> targetNode, boolean forceWritable) {
         try {
             VirtualFile vf;
 
             //open TaskRun and PipelineRun in read only mode
-            if (KIND_PIPELINERUN.equals(kind) || KIND_TASKRUN.equals(kind)) {
+            if (!forceWritable && (KIND_PIPELINERUN.equals(kind) || KIND_TASKRUN.equals(kind))) {
                 vf = new LightVirtualFile(name, content);
                 vf.setWritable(false);
             } else {

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/YAMLBuilder.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/YAMLBuilder.java
@@ -102,7 +102,7 @@ public class YAMLBuilder {
                 break;
             }
             case EMPTYDIR: {
-                workspaceNode.put(workspace.getKind().toString(), "{}");
+                workspaceNode.putObject(workspace.getKind().toString());
                 break;
             }
             default:

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/YAMLBuilder.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/YAMLBuilder.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 
+import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_PIPELINE;
 import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_PIPELINERUN;
 
 public class YAMLBuilder {
@@ -217,6 +218,14 @@ public class YAMLBuilder {
         triggersNode.add(triggerNode);
 
         return triggersNode;
+    }
+
+    public static ObjectNode createRun(ActionToRunModel model) {
+        if (model.getKind().equalsIgnoreCase(KIND_PIPELINE)) {
+            return createPipelineRun(model);
+        } else {
+            return createTaskRun(model);
+        }
     }
 
     public static ObjectNode createPipelineRun(ActionToRunModel model) {

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/actions/ActionToRunModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/model/actions/ActionToRunModel.java
@@ -93,6 +93,10 @@ public abstract class ActionToRunModel extends ConfigurationModel {
         return this.isValid;
     }
 
+    public ResourceConfigurationModel getResource() {
+        return resource;
+    }
+
     public String getErrorMessage() {
         return this.errorMessage;
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -135,6 +135,7 @@
       <action class="com.redhat.devtools.intellij.tektoncd.actions.StartAction" text="Start"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.MirrorStartAction" text="Mirror Start"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.StartLastRunAction" text="Start Last Run"/>
+      <action class="com.redhat.devtools.intellij.tektoncd.actions.task.CreateTaskRunTemplateAction" text="Create Run Template"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.AddTriggerAction" text="Add Trigger"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.logs.FollowLogsAction" text="Follow Logs"/>
       <action class="com.redhat.devtools.intellij.tektoncd.actions.logs.ShowLogsAction" text="Show Logs"/>

--- a/src/test/java/com/redhat/devtools/intellij/tektoncd/utils/YAMLBuilderTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/tektoncd/utils/YAMLBuilderTest.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.redhat.devtools.intellij.tektoncd.BaseTest;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Workspace;
 import com.redhat.devtools.intellij.tektoncd.utils.model.actions.AddTriggerModel;
+import com.redhat.devtools.intellij.tektoncd.utils.model.resources.TaskConfigurationModel;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -140,12 +141,12 @@ public class YAMLBuilderTest extends BaseTest {
         String content = load("task1.yaml");
         AddTriggerModel model = new AddTriggerModel(content, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
 
-        ObjectNode taskRunNode = YAMLBuilder.createTaskRun("task", model);
+        ObjectNode taskRunNode = YAMLBuilder.createTaskRun(model);
 
         assertEquals(taskRunNode.get("apiVersion").asText(), "tekton.dev/v1beta1");
         assertEquals(taskRunNode.get("kind").asText(), "TaskRun");
-        assertEquals(taskRunNode.get("metadata").get("generateName").asText(), "task-");
-        assertEquals(taskRunNode.get("spec").get("taskRef").get("name").asText(), "task");
+        assertEquals(taskRunNode.get("metadata").get("generateName").asText(), "foo-");
+        assertEquals(taskRunNode.get("spec").get("taskRef").get("name").asText(), "foo");
         assertFalse(taskRunNode.get("spec").has("serviceAccountName"));
         assertFalse(taskRunNode.get("spec").has("serviceAccountNames"));
         assertFalse(taskRunNode.get("spec").has("params"));
@@ -159,12 +160,12 @@ public class YAMLBuilderTest extends BaseTest {
         AddTriggerModel model = new AddTriggerModel(content, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
         model.setServiceAccount("sa");
 
-        ObjectNode taskRunNode = YAMLBuilder.createTaskRun("task", model);
+        ObjectNode taskRunNode = YAMLBuilder.createTaskRun(model);
 
         assertEquals(taskRunNode.get("apiVersion").asText(), "tekton.dev/v1beta1");
         assertEquals(taskRunNode.get("kind").asText(), "TaskRun");
-        assertEquals(taskRunNode.get("metadata").get("generateName").asText(), "task-");
-        assertEquals(taskRunNode.get("spec").get("taskRef").get("name").asText(), "task");
+        assertEquals(taskRunNode.get("metadata").get("generateName").asText(), "foo-");
+        assertEquals(taskRunNode.get("spec").get("taskRef").get("name").asText(), "foo");
         assertEquals(taskRunNode.get("spec").get("serviceAccountName").asText(), "sa");
         assertFalse(taskRunNode.get("spec").has("serviceAccountNames"));
         assertFalse(taskRunNode.get("spec").has("params"));
@@ -177,12 +178,12 @@ public class YAMLBuilderTest extends BaseTest {
         String content = load("task3.yaml");
         AddTriggerModel model = new AddTriggerModel(content, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
 
-        ObjectNode taskRunNode = YAMLBuilder.createTaskRun("task", model);
+        ObjectNode taskRunNode = YAMLBuilder.createTaskRun(model);
 
         assertEquals(taskRunNode.get("apiVersion").asText(), "tekton.dev/v1beta1");
         assertEquals(taskRunNode.get("kind").asText(), "TaskRun");
-        assertEquals(taskRunNode.get("metadata").get("generateName").asText(), "task-");
-        assertEquals(taskRunNode.get("spec").get("taskRef").get("name").asText(), "task");
+        assertEquals(taskRunNode.get("metadata").get("generateName").asText(), "foo-");
+        assertEquals(taskRunNode.get("spec").get("taskRef").get("name").asText(), "foo");
         assertFalse(taskRunNode.get("spec").has("serviceAccountName"));
         assertFalse(taskRunNode.get("spec").has("serviceAccountNames"));
         assertTrue(taskRunNode.get("spec").has("params"));
@@ -196,12 +197,12 @@ public class YAMLBuilderTest extends BaseTest {
         String content = load("task6.yaml");
         AddTriggerModel model = new AddTriggerModel(content, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
 
-        ObjectNode taskRunNode = YAMLBuilder.createTaskRun("task", model);
+        ObjectNode taskRunNode = YAMLBuilder.createTaskRun(model);
 
         assertEquals(taskRunNode.get("apiVersion").asText(), "tekton.dev/v1beta1");
         assertEquals(taskRunNode.get("kind").asText(), "TaskRun");
-        assertEquals(taskRunNode.get("metadata").get("generateName").asText(), "task-");
-        assertEquals(taskRunNode.get("spec").get("taskRef").get("name").asText(), "task");
+        assertEquals(taskRunNode.get("metadata").get("generateName").asText(), "foo-");
+        assertEquals(taskRunNode.get("spec").get("taskRef").get("name").asText(), "foo");
         assertFalse(taskRunNode.get("spec").has("serviceAccountName"));
         assertFalse(taskRunNode.get("spec").has("serviceAccountNames"));
         assertFalse(taskRunNode.get("spec").has("params"));
@@ -216,12 +217,12 @@ public class YAMLBuilderTest extends BaseTest {
         String content = load("task8.yaml");
         AddTriggerModel model = new AddTriggerModel(content, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
 
-        ObjectNode taskRunNode = YAMLBuilder.createTaskRun("task", model);
+        ObjectNode taskRunNode = YAMLBuilder.createTaskRun(model);
 
         assertEquals(taskRunNode.get("apiVersion").asText(), "tekton.dev/v1beta1");
         assertEquals(taskRunNode.get("kind").asText(), "TaskRun");
-        assertEquals(taskRunNode.get("metadata").get("generateName").asText(), "task-");
-        assertEquals(taskRunNode.get("spec").get("taskRef").get("name").asText(), "task");
+        assertEquals(taskRunNode.get("metadata").get("generateName").asText(), "foo-");
+        assertEquals(taskRunNode.get("spec").get("taskRef").get("name").asText(), "foo");
         assertFalse(taskRunNode.get("spec").has("serviceAccountName"));
         assertFalse(taskRunNode.get("spec").has("serviceAccountNames"));
         assertFalse(taskRunNode.get("spec").has("params"));
@@ -242,12 +243,12 @@ public class YAMLBuilderTest extends BaseTest {
             model.getWorkspaces().put("write-disallowed", new Workspace("foo2", Workspace.Kind.EMPTYDIR, "foo"));
         }
 
-        ObjectNode taskRunNode = YAMLBuilder.createTaskRun("task", model);
+        ObjectNode taskRunNode = YAMLBuilder.createTaskRun(model);
 
         assertEquals(taskRunNode.get("apiVersion").asText(), "tekton.dev/v1beta1");
         assertEquals(taskRunNode.get("kind").asText(), "TaskRun");
-        assertEquals(taskRunNode.get("metadata").get("generateName").asText(), "task-");
-        assertEquals(taskRunNode.get("spec").get("taskRef").get("name").asText(), "task");
+        assertEquals(taskRunNode.get("metadata").get("generateName").asText(), "foo-");
+        assertEquals(taskRunNode.get("spec").get("taskRef").get("name").asText(), "foo");
         assertFalse(taskRunNode.get("spec").has("serviceAccountName"));
         assertFalse(taskRunNode.get("spec").has("serviceAccountNames"));
         assertFalse(taskRunNode.get("spec").has("params"));
@@ -255,6 +256,50 @@ public class YAMLBuilderTest extends BaseTest {
         assertTrue(taskRunNode.get("spec").has("workspaces"));
         assertEquals(taskRunNode.get("spec").get("workspaces").get(0).get("name").asText(), "foo1");
         assertEquals(taskRunNode.get("spec").get("workspaces").get(1).get("name").asText(), "foo2");
+    }
+
+    @Test
+    public void checkTaskRunCreatedWithTaskConfigurationModelWithoutWorkspace() throws IOException {
+        String content = load("task5.yaml");
+        TaskConfigurationModel model = new TaskConfigurationModel(content);
+
+
+        ObjectNode taskRunNode = YAMLBuilder.createTaskRun(model);
+
+        assertEquals(taskRunNode.get("apiVersion").asText(), "tekton.dev/v1beta1");
+        assertEquals(taskRunNode.get("kind").asText(), "TaskRun");
+        assertEquals(taskRunNode.get("metadata").get("generateName").asText(), "foo-");
+        assertEquals(taskRunNode.get("spec").get("taskRef").get("name").asText(), "foo");
+        assertTrue(taskRunNode.get("spec").has("serviceAccountName"));
+        assertEquals(taskRunNode.get("spec").get("serviceAccountName").asText(), "");
+        assertFalse(taskRunNode.get("spec").has("serviceAccountNames"));
+        assertTrue(taskRunNode.get("spec").has("params"));
+        assertFalse(taskRunNode.get("spec").has("resources"));
+        assertFalse(taskRunNode.get("spec").has("workspaces"));
+    }
+
+    @Test
+    public void checkTaskRunCreatedWithTaskConfigurationModelWithWorkspace() throws IOException {
+        String content = load("task10.yaml");
+        TaskConfigurationModel model = new TaskConfigurationModel(content);
+
+
+        ObjectNode taskRunNode = YAMLBuilder.createTaskRun(model);
+
+        assertEquals(taskRunNode.get("apiVersion").asText(), "tekton.dev/v1beta1");
+        assertEquals(taskRunNode.get("kind").asText(), "TaskRun");
+        assertEquals(taskRunNode.get("metadata").get("generateName").asText(), "foo-");
+        assertEquals(taskRunNode.get("spec").get("taskRef").get("name").asText(), "foo");
+        assertTrue(taskRunNode.get("spec").has("serviceAccountName"));
+        assertEquals(taskRunNode.get("spec").get("serviceAccountName").asText(), "");
+        assertFalse(taskRunNode.get("spec").has("serviceAccountNames"));
+        assertFalse(taskRunNode.get("spec").has("params"));
+        assertFalse(taskRunNode.get("spec").has("resources"));
+        assertTrue(taskRunNode.get("spec").has("workspaces"));
+        assertEquals(taskRunNode.get("spec").get("workspaces").get(0).get("name").asText(), "write-allowed");
+        assertEquals(taskRunNode.get("spec").get("workspaces").get(1).get("name").asText(), "write-disallowed");
+        assertTrue(taskRunNode.get("spec").get("workspaces").get(0).has("EmptyDir"));
+        assertTrue(taskRunNode.get("spec").get("workspaces").get(1).has("EmptyDir"));
     }
 
     /////////////////////////////////////////////////////////
@@ -266,7 +311,7 @@ public class YAMLBuilderTest extends BaseTest {
         String content = load("task1.yaml");
         AddTriggerModel model = new AddTriggerModel(content, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
 
-        ObjectNode taskRunNode = YAMLBuilder.createTaskRun("task", model);
+        ObjectNode taskRunNode = YAMLBuilder.createTaskRun(model);
         ObjectNode triggerTemplateNode = YAMLBuilder.createTriggerTemplate("template", Collections.emptyList(), Arrays.asList(taskRunNode));
 
         assertEquals(triggerTemplateNode.get("apiVersion").asText(), "triggers.tekton.dev/v1alpha1");
@@ -281,7 +326,7 @@ public class YAMLBuilderTest extends BaseTest {
         String content = load("task1.yaml");
         AddTriggerModel model = new AddTriggerModel(content, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
 
-        ObjectNode taskRunNode = YAMLBuilder.createTaskRun("task", model);
+        ObjectNode taskRunNode = YAMLBuilder.createTaskRun(model);
         ObjectNode triggerTemplateNode = YAMLBuilder.createTriggerTemplate("template", Arrays.asList("param1", "param2"), Arrays.asList(taskRunNode));
 
         assertEquals(triggerTemplateNode.get("apiVersion").asText(), "triggers.tekton.dev/v1alpha1");

--- a/src/test/java/com/redhat/devtools/intellij/tektoncd/utils/YAMLBuilderTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/tektoncd/utils/YAMLBuilderTest.java
@@ -36,12 +36,12 @@ public class YAMLBuilderTest extends BaseTest {
         String content = load("pipeline1.yaml");
         AddTriggerModel model = new AddTriggerModel(content, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
 
-        ObjectNode pipelineRunNode = YAMLBuilder.createPipelineRun("pipeline", model);
+        ObjectNode pipelineRunNode = YAMLBuilder.createPipelineRun(model);
 
         assertEquals(pipelineRunNode.get("apiVersion").asText(), "tekton.dev/v1beta1");
         assertEquals(pipelineRunNode.get("kind").asText(), "PipelineRun");
-        assertEquals(pipelineRunNode.get("metadata").get("generateName").asText(), "pipeline-");
-        assertEquals(pipelineRunNode.get("spec").get("pipelineRef").get("name").asText(), "pipeline");
+        assertEquals(pipelineRunNode.get("metadata").get("generateName").asText(), "foo-");
+        assertEquals(pipelineRunNode.get("spec").get("pipelineRef").get("name").asText(), "foo");
         assertFalse(pipelineRunNode.get("spec").has("serviceAccountName"));
         assertFalse(pipelineRunNode.get("spec").has("serviceAccountNames"));
         assertFalse(pipelineRunNode.get("spec").has("params"));
@@ -55,12 +55,12 @@ public class YAMLBuilderTest extends BaseTest {
         AddTriggerModel model = new AddTriggerModel(content, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
         model.setServiceAccount("sa");
 
-        ObjectNode pipelineRunNode = YAMLBuilder.createPipelineRun("pipeline", model);
+        ObjectNode pipelineRunNode = YAMLBuilder.createPipelineRun(model);
 
         assertEquals(pipelineRunNode.get("apiVersion").asText(), "tekton.dev/v1beta1");
         assertEquals(pipelineRunNode.get("kind").asText(), "PipelineRun");
-        assertEquals(pipelineRunNode.get("metadata").get("generateName").asText(), "pipeline-");
-        assertEquals(pipelineRunNode.get("spec").get("pipelineRef").get("name").asText(), "pipeline");
+        assertEquals(pipelineRunNode.get("metadata").get("generateName").asText(), "foo-");
+        assertEquals(pipelineRunNode.get("spec").get("pipelineRef").get("name").asText(), "foo");
         assertEquals(pipelineRunNode.get("spec").get("serviceAccountName").asText(), "sa");
         assertFalse(pipelineRunNode.get("spec").has("serviceAccountNames"));
         assertFalse(pipelineRunNode.get("spec").has("params"));
@@ -73,12 +73,12 @@ public class YAMLBuilderTest extends BaseTest {
         String content = load("pipeline3.yaml");
         AddTriggerModel model = new AddTriggerModel(content, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
 
-        ObjectNode pipelineRunNode = YAMLBuilder.createPipelineRun("pipeline", model);
+        ObjectNode pipelineRunNode = YAMLBuilder.createPipelineRun(model);
 
         assertEquals(pipelineRunNode.get("apiVersion").asText(), "tekton.dev/v1beta1");
         assertEquals(pipelineRunNode.get("kind").asText(), "PipelineRun");
-        assertEquals(pipelineRunNode.get("metadata").get("generateName").asText(), "pipeline-");
-        assertEquals(pipelineRunNode.get("spec").get("pipelineRef").get("name").asText(), "pipeline");
+        assertEquals(pipelineRunNode.get("metadata").get("generateName").asText(), "foo-");
+        assertEquals(pipelineRunNode.get("spec").get("pipelineRef").get("name").asText(), "foo");
         assertFalse(pipelineRunNode.get("spec").has("serviceAccountName"));
         assertFalse(pipelineRunNode.get("spec").has("serviceAccountNames"));
         assertTrue(pipelineRunNode.get("spec").has("params"));
@@ -92,12 +92,12 @@ public class YAMLBuilderTest extends BaseTest {
         String content = load("pipeline4.yaml");
         AddTriggerModel model = new AddTriggerModel(content, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
 
-        ObjectNode pipelineRunNode = YAMLBuilder.createPipelineRun("pipeline", model);
+        ObjectNode pipelineRunNode = YAMLBuilder.createPipelineRun(model);
 
         assertEquals(pipelineRunNode.get("apiVersion").asText(), "tekton.dev/v1beta1");
         assertEquals(pipelineRunNode.get("kind").asText(), "PipelineRun");
-        assertEquals(pipelineRunNode.get("metadata").get("generateName").asText(), "pipeline-");
-        assertEquals(pipelineRunNode.get("spec").get("pipelineRef").get("name").asText(), "pipeline");
+        assertEquals(pipelineRunNode.get("metadata").get("generateName").asText(), "foo-");
+        assertEquals(pipelineRunNode.get("spec").get("pipelineRef").get("name").asText(), "foo");
         assertFalse(pipelineRunNode.get("spec").has("serviceAccountName"));
         assertFalse(pipelineRunNode.get("spec").has("serviceAccountNames"));
         assertFalse(pipelineRunNode.get("spec").has("params"));
@@ -117,12 +117,12 @@ public class YAMLBuilderTest extends BaseTest {
             model.getWorkspaces().put("recipe-store", new Workspace("foo2", Workspace.Kind.EMPTYDIR, "foo"));
         }
 
-        ObjectNode pipelineRunNode = YAMLBuilder.createPipelineRun("pipeline", model);
+        ObjectNode pipelineRunNode = YAMLBuilder.createPipelineRun(model);
 
         assertEquals(pipelineRunNode.get("apiVersion").asText(), "tekton.dev/v1beta1");
         assertEquals(pipelineRunNode.get("kind").asText(), "PipelineRun");
-        assertEquals(pipelineRunNode.get("metadata").get("generateName").asText(), "pipeline-");
-        assertEquals(pipelineRunNode.get("spec").get("pipelineRef").get("name").asText(), "pipeline");
+        assertEquals(pipelineRunNode.get("metadata").get("generateName").asText(), "foo-");
+        assertEquals(pipelineRunNode.get("spec").get("pipelineRef").get("name").asText(), "foo");
         assertFalse(pipelineRunNode.get("spec").has("serviceAccountName"));
         assertFalse(pipelineRunNode.get("spec").has("serviceAccountNames"));
         assertFalse(pipelineRunNode.get("spec").has("params"));

--- a/src/test/java/com/redhat/devtools/intellij/tektoncd/utils/YAMLBuilderTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/tektoncd/utils/YAMLBuilderTest.java
@@ -298,8 +298,8 @@ public class YAMLBuilderTest extends BaseTest {
         assertTrue(taskRunNode.get("spec").has("workspaces"));
         assertEquals(taskRunNode.get("spec").get("workspaces").get(0).get("name").asText(), "write-allowed");
         assertEquals(taskRunNode.get("spec").get("workspaces").get(1).get("name").asText(), "write-disallowed");
-        assertTrue(taskRunNode.get("spec").get("workspaces").get(0).has("EmptyDir"));
-        assertTrue(taskRunNode.get("spec").get("workspaces").get(1).has("EmptyDir"));
+        assertTrue(taskRunNode.get("spec").get("workspaces").get(0).has("emptyDir"));
+        assertTrue(taskRunNode.get("spec").get("workspaces").get(1).has("emptyDir"));
     }
 
     /////////////////////////////////////////////////////////


### PR DESCRIPTION
it resolves #289 

As discussed, this patch shows the *run that is going to be created in the preview panel of the start dialog

![image](https://user-images.githubusercontent.com/49404737/102518198-419a5100-4091-11eb-9004-d0896f8f094a.png)

To be in sync with vscode I also added the action to generate a taskrun template so the user can edit it in the editor. 

![image](https://user-images.githubusercontent.com/49404737/102518542-b5d4f480-4091-11eb-9ae8-aab4934340fc.png)

Then once the action is clicked a skeleton of the taskRun is opened and it works exactly as the other resources. When the user is ready to save, the IDE asks if it has to be pushed to the cluster.