### PR TITLE
display pipelinerun result as notification (#290)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/StartAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/StartAction.java
@@ -123,9 +123,7 @@ public class StartAction extends TektonAction {
                         followLogsAction.actionPerformed(namespace, runName, element.getClass(), tkncli);
                     }
 
-                    UIHelper.executeInUI(() -> {
-                        WatchHandler.get().setWatchByKind(tkncli, project, namespace, KIND_PIPELINERUN);
-                    });
+                    WatchHandler.get().setWatchByKind(tkncli, project, namespace, KIND_PIPELINERUN);
 
                     ParentableNode nodeToRefresh = element;
                     if (element instanceof PipelineRunNode || element instanceof TaskRunNode) {

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/StartAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/StartAction.java
@@ -15,6 +15,7 @@ import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.redhat.devtools.intellij.common.utils.ExecHelper;
 import com.redhat.devtools.intellij.common.utils.UIHelper;
@@ -32,6 +33,7 @@ import com.redhat.devtools.intellij.tektoncd.tree.TaskNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TaskRunNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TektonTreeStructure;
 import com.redhat.devtools.intellij.tektoncd.ui.wizard.StartWizard;
+import com.redhat.devtools.intellij.tektoncd.utils.WatchHandler;
 import com.redhat.devtools.intellij.tektoncd.utils.model.actions.StartResourceModel;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -45,6 +47,7 @@ import org.slf4j.LoggerFactory;
 
 import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_CLUSTERTASK;
 import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_PIPELINE;
+import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_PIPELINERUN;
 import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_TASK;
 import static com.redhat.devtools.intellij.tektoncd.Constants.NOTIFICATION_ID;
 
@@ -59,6 +62,7 @@ public class StartAction extends TektonAction {
     public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Tkn tkncli) {
         ParentableNode element = getElement(selected);
         String namespace = element.getNamespace();
+        Project project = element.getRoot().getProject();
         ExecHelper.submit(() -> {
             Notification notification;
             List<Resource> resources;
@@ -118,6 +122,10 @@ public class StartAction extends TektonAction {
                         FollowLogsAction followLogsAction = (FollowLogsAction) ActionManager.getInstance().getAction("FollowLogsAction");
                         followLogsAction.actionPerformed(namespace, runName, element.getClass(), tkncli);
                     }
+
+                    UIHelper.executeInUI(() -> {
+                        WatchHandler.get().setWatchByKind(tkncli, project, namespace, KIND_PIPELINERUN);
+                    });
 
                     ParentableNode nodeToRefresh = element;
                     if (element instanceof PipelineRunNode || element instanceof TaskRunNode) {

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/StartLastRunAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/StartLastRunAction.java
@@ -17,7 +17,6 @@ import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.intellij.common.utils.ExecHelper;
-import com.redhat.devtools.intellij.common.utils.UIHelper;
 import com.redhat.devtools.intellij.tektoncd.Constants;
 import com.redhat.devtools.intellij.tektoncd.actions.logs.FollowLogsAction;
 import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
@@ -27,11 +26,10 @@ import com.redhat.devtools.intellij.tektoncd.tree.PipelineNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TaskNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TektonTreeStructure;
 import com.redhat.devtools.intellij.tektoncd.utils.WatchHandler;
+import java.io.IOException;
+import javax.swing.tree.TreePath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.swing.tree.TreePath;
-import java.io.IOException;
 
 
 import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_PIPELINERUN;
@@ -60,9 +58,7 @@ public class StartLastRunAction extends TektonAction {
                     followLogsAction.actionPerformed(namespace, runName, element.getClass(), tkncli);
                 }
 
-                UIHelper.executeInUI(() -> {
-                    WatchHandler.get().setWatchByKind(tkncli, project, namespace, KIND_PIPELINERUN);
-                });
+                WatchHandler.get().setWatchByKind(tkncli, project, namespace, KIND_PIPELINERUN);
 
                 ((TektonTreeStructure) getTree(anActionEvent).getClientProperty(Constants.STRUCTURE_PROPERTY)).fireModified(element);
             } catch (IOException e) {

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/settings/SettingsConfigurable.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/settings/SettingsConfigurable.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.settings;
+
+import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.options.ConfigurationException;
+import javax.swing.JComponent;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.Nullable;
+
+public class SettingsConfigurable  implements Configurable {
+
+    private SettingsView mySettingsView;
+
+    @Override
+    public @Nls(capitalization = Nls.Capitalization.Title) String getDisplayName() {
+        return "Tekton Pipelines by Red Hat";
+    }
+
+    @Override
+    public @Nullable JComponent createComponent() {
+        mySettingsView = new SettingsView();
+        return mySettingsView.getPanel();
+    }
+
+    @Override
+    public boolean isModified() {
+        SettingsState settings = SettingsState.getInstance();
+        boolean modified = mySettingsView.getDisplayPipelineRunResultAsNotification() != settings.displayPipelineRunResultAsNotification;
+        return modified;
+    }
+
+    @Override
+    public void apply() throws ConfigurationException {
+        SettingsState settings = SettingsState.getInstance();
+        settings.displayPipelineRunResultAsNotification = mySettingsView.getDisplayPipelineRunResultAsNotification();
+    }
+
+    @Override
+    public void reset() {
+        SettingsState settings = SettingsState.getInstance();
+        mySettingsView.setDisplayPipelineRunResultAsNotification(settings.displayPipelineRunResultAsNotification);
+    }
+
+    @Override
+    public void disposeUIResources() {
+        mySettingsView = null;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/settings/SettingsState.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/settings/SettingsState.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2021 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/settings/SettingsState.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/settings/SettingsState.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.settings;
+
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@State(
+        name = "com.redhat.devtools.intellij.tektoncd.settings.AppSettingsState",
+        storages = {@Storage("TektonSettingsPlugin.xml")}
+)
+public class SettingsState implements PersistentStateComponent<SettingsState> {
+
+    public boolean displayPipelineRunResultAsNotification = true;
+
+    public static SettingsState getInstance() {
+        return ServiceManager.getService(SettingsState.class);
+    }
+
+    @Nullable
+    @Override
+    public SettingsState getState() {
+        return this;
+    }
+
+    @Override
+    public void loadState(@NotNull SettingsState state) {
+        XmlSerializerUtil.copyBean(state, this);
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/settings/SettingsView.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/settings/SettingsView.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.settings;
+
+import com.intellij.ui.components.JBCheckBox;
+import com.intellij.util.ui.FormBuilder;
+import javax.swing.JPanel;
+
+public class SettingsView {
+    private final JPanel myMainPanel;
+    private final JBCheckBox chkDisplayPipelineRunResultAsNotification = new JBCheckBox("Display PipelineRuns result as notification");
+
+    public SettingsView() {
+        myMainPanel = FormBuilder.createFormBuilder()
+                .addComponent(chkDisplayPipelineRunResultAsNotification, 1)
+                .addComponentFillVertically(new JPanel(), 0)
+                .getPanel();
+    }
+
+    public JPanel getPanel() {
+        return myMainPanel;
+    }
+
+    public boolean getDisplayPipelineRunResultAsNotification() {
+        return chkDisplayPipelineRunResultAsNotification.isSelected();
+    }
+
+    public void setDisplayPipelineRunResultAsNotification(boolean newStatus) {
+        chkDisplayPipelineRunResultAsNotification.setSelected(newStatus);
+    }
+
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/hub/HubMarketplaceTab.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/hub/HubMarketplaceTab.java
@@ -12,16 +12,8 @@ package com.redhat.devtools.intellij.tektoncd.ui.hub;
 
 import com.google.common.base.Strings;
 import com.intellij.icons.AllIcons;
-import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
-import com.intellij.notification.Notifications;
-import com.intellij.openapi.ui.MessageType;
-import com.intellij.openapi.ui.popup.Balloon;
-import com.intellij.openapi.ui.popup.JBPopupFactory;
-import com.intellij.openapi.wm.StatusBar;
-import com.intellij.openapi.wm.WindowManager;
 import com.intellij.ui.DocumentAdapter;
-import com.intellij.ui.awt.RelativePoint;
 import com.intellij.ui.border.CustomLineBorder;
 import com.intellij.ui.components.JBPanelWithEmptyText;
 import com.intellij.util.ui.JBUI;
@@ -30,6 +22,7 @@ import com.redhat.devtools.intellij.tektoncd.hub.invoker.ApiCallback;
 import com.redhat.devtools.intellij.tektoncd.hub.invoker.ApiException;
 import com.redhat.devtools.intellij.tektoncd.hub.model.ResourceData;
 import com.redhat.devtools.intellij.tektoncd.hub.model.Resources;
+import com.redhat.devtools.intellij.tektoncd.utils.NotificationHelper;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.event.MouseEvent;
@@ -52,7 +45,6 @@ import org.jetbrains.annotations.NotNull;
 
 
 import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_CLUSTERTASK;
-import static com.redhat.devtools.intellij.tektoncd.Constants.NOTIFICATION_ID;
 import static com.redhat.devtools.intellij.tektoncd.ui.UIConstants.MAIN_BG_COLOR;
 import static com.redhat.devtools.intellij.tektoncd.ui.UIConstants.SEARCH_FIELD_BORDER_COLOR;
 
@@ -181,24 +173,10 @@ public class HubMarketplaceTab extends HubDialogTab {
                 hubItem.updateBottomPanel(warningNameAlreadyUsed);
             }
             if (installed != Constants.InstallStatus.ERROR) {
-                notify("Save Successful", kindToBeSaved + " " + resource.getName() + " has been saved!", NotificationType.INFORMATION, true);
+                NotificationHelper.notify(model.getProject(), "Save Successful", resource.getKind() + " " + resource.getName() + " has been saved!", NotificationType.INFORMATION, true);
             }
         } catch (IOException ex) {
-            notify("Error", "An error occurred while saving " + kindToBeSaved + " " + resource.getName() + "\n" + ex.getLocalizedMessage(), NotificationType.ERROR, false);
-        }
-    }
-
-    private void notify(String title, String content, NotificationType type, boolean withBalloon) {
-        Notification notification;
-        notification = new Notification(NOTIFICATION_ID, title, content, type);
-        Notifications.Bus.notify(notification);
-        if (withBalloon) {
-            StatusBar statusBar = WindowManager.getInstance().getStatusBar(model.getProject());
-            JBPopupFactory.getInstance()
-                    .createHtmlTextBalloonBuilder(content, (type == NotificationType.ERROR ? MessageType.ERROR : MessageType.INFO), null)
-                    .setFadeoutTime(7500)
-                    .createBalloon()
-                    .show(RelativePoint.getNorthEastOf(statusBar.getComponent()), Balloon.Position.atRight);
+            NotificationHelper.notify(model.getProject(), "Error", "An error occurred while saving " + resource.getKind() + " " + resource.getName() + "\n" + ex.getLocalizedMessage(), NotificationType.ERROR, false);
         }
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/NotificationHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/NotificationHelper.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.utils;
+
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.MessageType;
+import com.intellij.openapi.ui.popup.Balloon;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.openapi.wm.StatusBar;
+import com.intellij.openapi.wm.WindowManager;
+import com.intellij.ui.awt.RelativePoint;
+
+
+import static com.redhat.devtools.intellij.tektoncd.Constants.NOTIFICATION_ID;
+
+public class NotificationHelper {
+
+    public static void notify(Project project, String title, String content, NotificationType type, boolean withBalloon) {
+            Notification notification;
+            notification = new Notification(NOTIFICATION_ID, title, content, type);
+            Notifications.Bus.notify(notification);
+            if (withBalloon) {
+                notifyWithBalloon(project, content, type);
+            }
+    }
+
+    public static void notifyWithBalloon(Project project, String content, NotificationType type) {
+        StatusBar statusBar = WindowManager.getInstance().getStatusBar(project);
+        JBPopupFactory.getInstance()
+                .createHtmlTextBalloonBuilder(content, (type == NotificationType.ERROR ? MessageType.ERROR : MessageType.INFO), null)
+                .setFadeoutTime(7500)
+                .createBalloon()
+                .show(RelativePoint.getNorthEastOf(statusBar.getComponent()), Balloon.Position.atRight);
+    }
+
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/NotificationHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/NotificationHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2021 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -20,6 +20,7 @@ import com.intellij.openapi.ui.popup.JBPopupFactory;
 import com.intellij.openapi.wm.StatusBar;
 import com.intellij.openapi.wm.WindowManager;
 import com.intellij.ui.awt.RelativePoint;
+import com.redhat.devtools.intellij.common.utils.UIHelper;
 
 
 import static com.redhat.devtools.intellij.tektoncd.Constants.NOTIFICATION_ID;
@@ -36,12 +37,15 @@ public class NotificationHelper {
     }
 
     public static void notifyWithBalloon(Project project, String content, NotificationType type) {
-        StatusBar statusBar = WindowManager.getInstance().getStatusBar(project);
-        JBPopupFactory.getInstance()
-                .createHtmlTextBalloonBuilder(content, (type == NotificationType.ERROR ? MessageType.ERROR : MessageType.INFO), null)
-                .setFadeoutTime(7500)
-                .createBalloon()
-                .show(RelativePoint.getNorthEastOf(statusBar.getComponent()), Balloon.Position.atRight);
+        UIHelper.executeInUI(() -> {
+                StatusBar statusBar = WindowManager.getInstance().getStatusBar(project);
+                JBPopupFactory.getInstance()
+                    .createHtmlTextBalloonBuilder(content, (type == NotificationType.ERROR ? MessageType.ERROR : MessageType.INFO), null)
+                    .setFadeoutTime(7500)
+                    .createBalloon()
+                    .show(RelativePoint.getNorthEastOf(statusBar.getComponent()), Balloon.Position.atRight);
+        });
+
     }
 
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/WatchHandler.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/WatchHandler.java
@@ -15,6 +15,7 @@ import com.intellij.notification.NotificationType;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.treeStructure.Tree;
 import com.redhat.devtools.intellij.common.utils.DateHelper;
+import com.redhat.devtools.intellij.tektoncd.settings.SettingsState;
 import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
 import com.redhat.devtools.intellij.tektoncd.tree.ClusterTasksNode;
 import com.redhat.devtools.intellij.tektoncd.tree.ClusterTriggerBindingsNode;
@@ -221,7 +222,8 @@ public class WatchHandler {
                     RefreshQueue.get().addAll(watches.get(watchId).getNodes());
                 }
                 // watches for *runs are always active so there also could be nothing to refresh, only a notification to display
-                if (!(resource instanceof io.fabric8.tekton.pipeline.v1beta1.PipelineRun) ||
+                if (!SettingsState.getInstance().displayPipelineRunResultAsNotification ||
+                        !(resource instanceof io.fabric8.tekton.pipeline.v1beta1.PipelineRun) ||
                         Strings.isNullOrEmpty(((PipelineRun) resource).getStatus().getCompletionTime())) {
                     return;
                 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/WatchHandler.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/WatchHandler.java
@@ -114,7 +114,7 @@ public class WatchHandler {
             }
             watches.put(watchId, null);
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.warn(e.getLocalizedMessage());
         }
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/WatchHandler.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/WatchHandler.java
@@ -10,8 +10,11 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.tektoncd.utils;
 
-import com.intellij.ide.util.treeView.PresentableNodeDescriptor;
+import com.google.common.base.Strings;
+import com.intellij.notification.NotificationType;
+import com.intellij.openapi.project.Project;
 import com.intellij.ui.treeStructure.Tree;
+import com.redhat.devtools.intellij.common.utils.DateHelper;
 import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
 import com.redhat.devtools.intellij.tektoncd.tree.ClusterTasksNode;
 import com.redhat.devtools.intellij.tektoncd.tree.ClusterTriggerBindingsNode;
@@ -28,11 +31,15 @@ import com.redhat.devtools.intellij.tektoncd.tree.TaskRunsNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TasksNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TriggerBindingsNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TriggerTemplatesNode;
+import io.fabric8.knative.internal.pkg.apis.Condition;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.tekton.pipeline.v1beta1.PipelineRun;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -44,7 +51,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
+import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_PIPELINERUN;
+import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_PIPELINERUNS;
 import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_TASK;
+import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_TASKRUN;
+import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_TASKRUNS;
 
 public class WatchHandler {
     private static final Logger logger = LoggerFactory.getLogger(WatchHandler.class);
@@ -87,12 +98,31 @@ public class WatchHandler {
 
     }
 
+    public void setWatchByKind(Tkn tkn, Project project, String namespace, String kind) {
+        String watchId = getWatchId(namespace, kind);
+        if (this.watches.containsKey(watchId)) {
+            return;
+        }
+
+        try {
+            Watcher watcher = getWatcher(watchId, project);
+            if (kind.equalsIgnoreCase(KIND_PIPELINERUN)) {
+                tkn.watchPipelineRuns(namespace, watcher);
+            } else if (kind.equalsIgnoreCase(KIND_TASKRUN)) {
+                tkn.watchTaskRuns(namespace, watcher);
+            }
+            watches.put(watchId, null);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
     public void setWatchByNode(ParentableNode<?> element, TreePath treePath) {
         Tkn tkn = element.getRoot().getTkn();
 
         String namespace = element.getNamespace();
         String watchId = getWatchId(element);
-        Watcher watcher = getWatcher(watchId);
+        Watcher watcher = getWatcher(watchId, element.getRoot().getProject());
         Watch watch = null;
         WatchNodes wn = null;
 
@@ -100,8 +130,10 @@ public class WatchHandler {
         // (e.g a taskRuns watcher, when a change happens, could update multiple nodes such as a single Task node and the TaskRuns node)
         if (this.watches.containsKey(watchId)) {
             wn = this.watches.get(watchId);
-            wn.addNode(element, treePath);
-            return;
+            if (wn != null) {
+                wn.addNode(element, treePath);
+                return;
+            }
         }
 
         try {
@@ -152,7 +184,11 @@ public class WatchHandler {
         if (watches.containsKey(watchId)) {
             WatchNodes wn = watches.get(watchId);
             wn.removeNode(element, treePath);
-            if (wn.isNodesEmpty()) {
+            // kind of temporary hack until we only show the active namespace.
+            // Prevent from closing the watch for *runs that must be always active
+            if (wn != null && wn.isNodesEmpty() &&
+                    !(watchId.equalsIgnoreCase(element.getNamespace() + "-" + KIND_TASKRUNS) ||
+                     watchId.equalsIgnoreCase(element.getNamespace() + "-" + KIND_PIPELINERUNS))) {
                 wn.getWatch().close();
                 watches.remove(watchId);
             }
@@ -163,10 +199,10 @@ public class WatchHandler {
         String name = element.getName();
         if (element instanceof TaskNode || element instanceof PipelineRunNode) {
             // we are expanding a single task or pipelinerun node and we want it to refresh if its taskruns change
-            name = "TaskRuns";
+            name = KIND_TASKRUN;
         } else if (element instanceof PipelineNode) {
             // we are expanding a single pipeline node and we want it to refresh if its pipelineruns change
-            name = "PipelineRuns";
+            name = KIND_PIPELINERUN;
         }
         return getWatchId(element.getNamespace(), name);
     }
@@ -175,11 +211,33 @@ public class WatchHandler {
         return (namespace + "-" + name).toLowerCase();
     }
 
-    public <T extends HasMetadata> Watcher<T> getWatcher(String watchId) {
+    public <T extends HasMetadata> Watcher<T> getWatcher(String watchId, Project project) {
+        Instant watcherStartTime = Instant.now();
         return new Watcher<T>() {
             @Override
             public void eventReceived(Action action, T resource) {
-                RefreshQueue.get().addAll(watches.get(watchId).getNodes());
+                WatchNodes watchNode = watches.get(watchId);
+                if (watchNode != null) {
+                    RefreshQueue.get().addAll(watches.get(watchId).getNodes());
+                }
+                // watches for *runs are always active so there also could be nothing to refresh, only a notification to display
+                if (!(resource instanceof io.fabric8.tekton.pipeline.v1beta1.PipelineRun) ||
+                        Strings.isNullOrEmpty(((PipelineRun) resource).getStatus().getCompletionTime())) {
+                    return;
+                }
+                Instant completion = Instant.parse(((PipelineRun) resource).getStatus().getCompletionTime());
+                if (Duration.between(watcherStartTime, completion).getSeconds() > 0) {
+                    List<Condition> conditions = ((PipelineRun) resource).getStatus().getConditions();
+                    if (!conditions.isEmpty()) {
+                        String name = "PipelineRun " + resource.getMetadata().getName();
+                        String executionTime = DateHelper.humanizeDate(Instant.parse(((PipelineRun) resource).getStatus().getStartTime()), completion);
+                        if (conditions.get(0).getStatus().equalsIgnoreCase("true")) {
+                            NotificationHelper.notifyWithBalloon(project, name + " successfully completed in " + executionTime, NotificationType.INFORMATION);
+                        } else {
+                            NotificationHelper.notifyWithBalloon(project, name + " failed", NotificationType.ERROR);
+                        }
+                    }
+                }
             }
 
             @Override

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -108,6 +108,10 @@
 
   <extensions defaultExtensionNs="com.intellij">
     <!-- Add your extensions here -->
+    <applicationConfigurable parentId="tools" instance="com.redhat.devtools.intellij.tektoncd.settings.SettingsConfigurable"
+                             id="com.redhat.devtools.intellij.tektoncd.settings.SettingsConfigurable"
+                             displayName="Tekton Pipelines by Red Hat"/>
+    <applicationService serviceImplementation="com.redhat.devtools.intellij.tektoncd.settings.SettingsState"/>
     <fileDocumentSynchronizationVetoer implementation="com.redhat.devtools.intellij.tektoncd.listener.SaveInEditorListener" order="first" />
     <completion.contributor language="any" implementationClass="com.redhat.devtools.intellij.tektoncd.completion.DictionaryContributor"/>
     <toolWindow id="Tekton" anchor="left" factoryClass="com.redhat.devtools.intellij.tektoncd.WindowToolFactory" icon="/images/cluster.png"/>


### PR DESCRIPTION
it resolves #290 

When enabled, the result of a pipelinerun is displayed as a notification balloon (as in vscode)
![image](https://user-images.githubusercontent.com/49404737/103532085-e5a23b80-4e8a-11eb-9e30-a756caec517a.png)

The setting is set to enabled, not sure if we want to keep it disabled at start
![image](https://user-images.githubusercontent.com/49404737/103532160-08cceb00-4e8b-11eb-911e-23f37ceaa978.png)
