### PR TITLE
Add show logs to eventListener #257

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/logs/ShowLogsAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/logs/ShowLogsAction.java
@@ -13,6 +13,7 @@ package com.redhat.devtools.intellij.tektoncd.actions.logs;
 import com.intellij.openapi.ui.Messages;
 import com.redhat.devtools.intellij.common.utils.UIHelper;
 import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
+import com.redhat.devtools.intellij.tektoncd.tree.EventListenerNode;
 import com.redhat.devtools.intellij.tektoncd.tree.PipelineNode;
 import com.redhat.devtools.intellij.tektoncd.tree.PipelineRunNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TaskNode;
@@ -25,12 +26,18 @@ import java.io.IOException;
 public class ShowLogsAction extends LogsBaseAction {
     private static final Logger logger = LoggerFactory.getLogger(ShowLogsAction.class);
 
+    public ShowLogsAction() {
+        super(EventListenerNode.class);
+    }
+
     public void actionPerformed(String namespace, String resourceName, Class nodeClass,  Tkn tkncli) {
         try {
             if (PipelineNode.class.equals(nodeClass) || PipelineRunNode.class.equals(nodeClass)) {
                 tkncli.showLogsPipelineRun(namespace, resourceName);
             } else if (TaskNode.class.equals(nodeClass) || TaskRunNode.class.equals(nodeClass)) {
                 tkncli.showLogsTaskRun(namespace, resourceName);
+            } else if (EventListenerNode.class.equals(nodeClass)) {
+                tkncli.showLogsEventListener(namespace, resourceName);
             }
         } catch (IOException e) {
             UIHelper.executeInUI(() ->

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/Tkn.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/Tkn.java
@@ -512,14 +512,6 @@ public interface Tkn {
     void followLogsTaskRun(String namespace, String taskRun) throws IOException;
 
     /**
-     * Follow logs for an EventListener
-     * @param namespace the namespace to use
-     * @param el name of the EventListener
-     * @throws IOException if communication errored
-     */
-    void followLogsEventListener(String namespace, String el) throws IOException;
-
-    /**
      * Get TaskRun configuration in YAML
      *
      * @param namespace the namespace to use

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/Tkn.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/Tkn.java
@@ -487,6 +487,14 @@ public interface Tkn {
     void showLogsTaskRun(String namespace, String taskRun) throws IOException;
 
     /**
+     * Get logs for an eventListener
+     * @param namespace the namespace to use
+     * @param el name of the eventListener
+     * @throws IOException if communication errored
+     */
+    void showLogsEventListener(String namespace, String el) throws IOException;
+
+    /**
      * Follow logs for a PipelineRun
      *
      * @param namespace the namespace to use
@@ -502,6 +510,14 @@ public interface Tkn {
      * @throws IOException if communication errored
      */
     void followLogsTaskRun(String namespace, String taskRun) throws IOException;
+
+    /**
+     * Follow logs for an EventListener
+     * @param namespace the namespace to use
+     * @param el name of the EventListener
+     * @throws IOException if communication errored
+     */
+    void followLogsEventListener(String namespace, String el) throws IOException;
 
     /**
      * Get TaskRun configuration in YAML

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCli.java
@@ -489,6 +489,11 @@ public class TknCli implements Tkn {
     }
 
     @Override
+    public void showLogsEventListener(String namespace, String el) throws IOException {
+        ExecHelper.executeWithTerminal(project, Constants.TERMINAL_TITLE, false, envVars, command, "el", "logs", el, "-n", namespace);
+    }
+
+    @Override
     public void followLogsPipelineRun(String namespace, String pipelineRun) throws IOException {
         ExecHelper.executeWithTerminal(project, Constants.TERMINAL_TITLE,false, envVars, command, "pipelinerun", "logs", pipelineRun, "-f", "-n", namespace);
     }
@@ -496,6 +501,11 @@ public class TknCli implements Tkn {
     @Override
     public void followLogsTaskRun(String namespace, String taskRun) throws IOException {
         ExecHelper.executeWithTerminal(project, Constants.TERMINAL_TITLE, false, envVars, command, "taskrun", "logs", taskRun, "-f", "-n", namespace);
+    }
+
+    @Override
+    public void followLogsEventListener(String namespace, String el) throws IOException {
+        ExecHelper.executeWithTerminal(project, Constants.TERMINAL_TITLE, false, envVars, command, "el", "logs", el, "-f", "-n", namespace);
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCli.java
@@ -504,11 +504,6 @@ public class TknCli implements Tkn {
     }
 
     @Override
-    public void followLogsEventListener(String namespace, String el) throws IOException {
-        ExecHelper.executeWithTerminal(project, Constants.TERMINAL_TITLE, false, envVars, command, "el", "logs", el, "-f", "-n", namespace);
-    }
-
-    @Override
     public String getTaskRunYAML(String namespace, String taskRun) throws IOException {
         return ExecHelper.execute(command, envVars, "taskrun", "describe", taskRun, "-n", namespace, "-o", "yaml");
     }


### PR DESCRIPTION
it resolves #257 

@jeffmaury for eventiListeners there is no `follow logs` action but they implemented the tail feature which allows to display only the latest rows. E.g `tkn el logs <name> -t 2` -> prints the last 2 rows of the logs.
It's quite useful when there are long logs but how do we want to show this option? Create a new action or to display an input when the `show logs` is clicked?
