### PR TITLE
fix: Allows parameter array to accept empty array as value (#313)

### DIFF
--- a/src/it/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCliPipelineTest.java
+++ b/src/it/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCliPipelineTest.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.intellij.tektoncd.tkn;
 
 import com.redhat.devtools.intellij.tektoncd.TestUtils;
+import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
 import io.fabric8.tekton.client.TektonClient;
 import java.io.IOException;
 import java.util.Arrays;
@@ -18,6 +19,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.junit.Test;
@@ -106,10 +108,10 @@ public class TknCliPipelineTest extends TknCliTest {
         List<String> pipelines = tkn.getPipelines(NAMESPACE);
         assertTrue(pipelines.contains(PIPELINE_NAME));
         // start pipeline and verify taskrun and pipelinerun has been created
-        Map<String, String> params = new HashMap<>();
-        params.put("first", "1");
-        params.put("second", "2");
-        params.put("third", "3");
+        Map<String, Input> params = new HashMap<>();
+        params.put("first", new Input("name", "string", Input.Kind.PARAMETER, "value", Optional.empty(), Optional.empty()));
+        params.put("second", new Input("name2", "string", Input.Kind.PARAMETER, "value2", Optional.empty(), Optional.empty()));
+        params.put("third", new Input("name3", "string", Input.Kind.PARAMETER, "value3", Optional.empty(), Optional.empty()));
         tkn.startPipeline(NAMESPACE, PIPELINE_NAME, params, Collections.emptyMap(), "", Collections.emptyMap(), Collections.emptyMap(), "");
         io.fabric8.tekton.pipeline.v1beta1.PipelineRun pRun = tkn.getClient(TektonClient.class).v1beta1().pipelineRuns().inNamespace(NAMESPACE)
                 .waitUntilCondition(pipelineRun -> pipelineRun.getMetadata().getName() != null && pipelineRun.getMetadata().getName().startsWith(PIPELINE_NAME), 10, TimeUnit.MINUTES);

--- a/src/it/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCliTaskTest.java
+++ b/src/it/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCliTaskTest.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.intellij.tektoncd.tkn;
 
 import com.redhat.devtools.intellij.tektoncd.TestUtils;
+import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
 import io.fabric8.tekton.client.TektonClient;
 import java.io.IOException;
 import java.util.Arrays;
@@ -18,6 +19,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.junit.Test;
@@ -95,9 +97,9 @@ public class TknCliTaskTest extends TknCliTest {
         List<String> tasks = tkn.getTasks(NAMESPACE).stream().map(task -> task.getMetadata().getName()).collect(Collectors.toList());
         assertTrue(tasks.contains(TASK_NAME));
         // start task and verify taskrun has been created
-        Map<String, String> params = new HashMap<>();
-        params.put("first", "1");
-        params.put("second", "2");
+        Map<String, Input> params = new HashMap<>();
+        params.put("first", new Input("name", "string", Input.Kind.PARAMETER, "value", Optional.empty(), Optional.empty()));
+        params.put("second", new Input("name2", "string", Input.Kind.PARAMETER, "value2", Optional.empty(), Optional.empty()));
         tkn.startTask(NAMESPACE, TASK_NAME, params, Collections.emptyMap(), Collections.emptyMap(), "", Collections.emptyMap(), "");
         io.fabric8.tekton.pipeline.v1beta1.TaskRun tRun = tkn.getClient(TektonClient.class).v1beta1().taskRuns().inNamespace(NAMESPACE)
                 .waitUntilCondition(taskRun -> taskRun.getMetadata().getName() != null && taskRun.getMetadata().getName().startsWith(TASK_NAME), 10, TimeUnit.MINUTES);

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/StartAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/StartAction.java
@@ -27,6 +27,7 @@ import com.redhat.devtools.intellij.tektoncd.telemetry.TelemetryService;
 import com.redhat.devtools.intellij.tektoncd.tkn.Resource;
 import com.redhat.devtools.intellij.tektoncd.tkn.Run;
 import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
+import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Workspace;
 import com.redhat.devtools.intellij.tektoncd.tree.ClusterTaskNode;
 import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
@@ -109,8 +110,8 @@ public class StartAction extends TektonAction {
             try {
                 String serviceAccount = model.getServiceAccount();
                 Map<String, String> taskServiceAccount = model.getTaskServiceAccounts();
-                Map<String, String> params = model.getParams().stream().collect(Collectors.toMap(param -> param.name(), param -> param.value()));
                 createNewVolumes(model.getWorkspaces(), tkncli);
+                Map<String, Input> params = model.getParams().stream().collect(Collectors.toMap(param -> param.name(), param -> param));
                 Map<String, Workspace> workspaces = model.getWorkspaces();
                 Map<String, String> inputResources = model.getInputResources().stream().collect(Collectors.toMap(input -> input.name(), input -> input.value()));
                 Map<String, String> outputResources = model.getOutputResources().stream().collect(Collectors.toMap(output -> output.name(), output -> output.value()));
@@ -189,7 +190,7 @@ public class StartAction extends TektonAction {
                          StartResourceModel model,
                          String serviceAccount,
                          Map<String, String> taskServiceAccount,
-                         Map<String, String> params,
+                         Map<String, Input> params,
                          Map<String, Workspace> workspaces,
                          Map<String, String> inputResources,
                          Map<String, String> outputResources,

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/Tkn.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/Tkn.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.tektoncd.tkn;
 
+import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Workspace;
 import com.redhat.devtools.intellij.tektoncd.ui.toolwindow.findusage.RefUsage;
 import io.fabric8.kubernetes.client.Watch;
@@ -20,7 +21,6 @@ import io.fabric8.tekton.pipeline.v1beta1.ClusterTask;
 import io.fabric8.tekton.pipeline.v1beta1.Pipeline;
 import io.fabric8.tekton.pipeline.v1beta1.Task;
 import io.fabric8.tekton.resource.v1alpha1.PipelineResource;
-
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
@@ -437,7 +437,7 @@ public interface Tkn {
      * @throws IOException if communication errored
      * @return PipelineRun name
      */
-    String startPipeline(String namespace, String pipeline, Map<String, String> parameters, Map<String, String> inputResources, String serviceAccount, Map<String, String> taskServiceAccount, Map<String, Workspace> workspaces, String runPrefixName) throws IOException;
+    String startPipeline(String namespace, String pipeline, Map<String, Input> parameters, Map<String, String> inputResources, String serviceAccount, Map<String, String> taskServiceAccount, Map<String, Workspace> workspaces, String runPrefixName) throws IOException;
 
     /**
      * Re-run the pipeline using last pipelinerun values
@@ -463,7 +463,7 @@ public interface Tkn {
      * @throws IOException if communication errored
      * @return TaskRun name
      */
-    String startTask(String namespace, String task, Map<String, String> parameters, Map<String, String> inputResources, Map<String, String> outputResources, String serviceAccount, Map<String, Workspace> workspaces, String runPrefixName) throws IOException;
+    String startTask(String namespace, String task, Map<String, Input> parameters, Map<String, String> inputResources, Map<String, String> outputResources, String serviceAccount, Map<String, Workspace> workspaces, String runPrefixName) throws IOException;
 
     /**
      * Start the execution of a task
@@ -479,7 +479,7 @@ public interface Tkn {
      * @throws IOException if communication errored
      * @return TaskRun name
      */
-    String startClusterTask(String namespace, String clusterTask, Map<String, String> parameters, Map<String, String> inputResources, Map<String, String> outputResources, String serviceAccount, Map<String, Workspace> workspaces, String runPrefixName) throws IOException;
+    String startClusterTask(String namespace, String clusterTask, Map<String, Input> parameters, Map<String, String> inputResources, Map<String, String> outputResources, String serviceAccount, Map<String, Workspace> workspaces, String runPrefixName) throws IOException;
 
     /**
      * Re-run the task using last taskrun values

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCli.java
@@ -528,7 +528,7 @@ public class TknCli implements Tkn {
     private List<String> paramsToArgsList(Map<String, Input> argMap, String flag) {
         List<String> args = new ArrayList<>();
         if (argMap != null) {
-            argMap.entrySet().stream().forEach(param -> {
+            argMap.entrySet().forEach(param -> {
                 if (!param.getKey().isEmpty() && !(param.getValue().type().equalsIgnoreCase("string") && param.getValue().value().isEmpty())) {
                     args.add(flag);
                     args.add(param.getKey() + "=" + param.getValue().value());

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/component/field/Input.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/component/field/Input.java
@@ -30,6 +30,15 @@ public class Input {
 
     public Input() {}
 
+    public Input(String name, String type, Kind kind, String value, Optional<String> description, Optional<String> defaultValue) {
+        this.name = name;
+        this.type = type;
+        this.kind = kind;
+        this.value = value;
+        this.description = description;
+        this.defaultValue = defaultValue;
+    }
+
     public String name() {
         return name;
     }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/ParametersStep.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/ParametersStep.java
@@ -51,7 +51,7 @@ public class ParametersStep extends BaseStep {
         final int[] row = {1};
         textFields.keySet().stream().forEach(param -> {
             JTextField field = textFields.get(param);
-            if (!isValid(field)) {
+            if (!isValid(param, field)) {
                 field.setBorder(RED_BORDER_SHOW_ERROR);
                 JLabel lblErrorText = new JLabel("Please enter a value.");
                 lblErrorText.setForeground(Color.red);
@@ -104,7 +104,7 @@ public class ParametersStep extends BaseStep {
             if (input.type().equals("string")) {
                 tooltip += "The parameter " + input.name() + " expects a string value.";
             } else {
-                tooltip += "The parameter " + input.name() + " expects an array value (e.g. val1,val2,val3 ...).";
+                tooltip += "The parameter " + input.name() + " expects an array value (e.g. val1,val2,val3 ...). Leave it empty for an empty array.";
             }
             JLabel lblNameParam = new JLabel(label);
             addComponent(lblNameParam, null, BORDER_LABEL_NAME, ROW_DIMENSION, 0, row[0], GridBagConstraints.NORTHWEST);
@@ -140,7 +140,7 @@ public class ParametersStep extends BaseStep {
             public void update() {
                 setInputValue(model.getParams(), idParam, txtValueParam.getText());
                 // reset error graphics if an error occurred earlier
-                if (isValid(txtValueParam)) {
+                if (isValid(idParam, txtValueParam)) {
                     txtValueParam.setBorder(defaultBorder);
                     if (errorFieldsByRow.containsKey(row)) {
                         deleteComponent(errorFieldsByRow.get(row));
@@ -151,7 +151,11 @@ public class ParametersStep extends BaseStep {
         });
     }
 
-    private boolean isValid(JTextField component) {
-        return !component.getText().isEmpty();
+    private boolean isValid(String name, JTextField component) {
+        String type = model.getParams().stream().filter(in -> in.name().equalsIgnoreCase(name)).map(in -> in.type()).findFirst().get();
+        if (type.equalsIgnoreCase("string")) {
+            return !component.getText().isEmpty();
+        }
+        return true;
     }
 }

--- a/src/test/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCliTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCliTest.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.intellij.tektoncd.tkn;
 
 import com.redhat.devtools.intellij.common.utils.ExecHelper;
+import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Input;
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Workspace;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
@@ -28,11 +29,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -40,8 +43,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -161,9 +162,9 @@ public class TknCliTest {
 
     @Test
     public void checkRightArgsWhenStartingPipelineWithParameters() throws IOException {
-        Map<String, String> params = new HashMap<>();
-        params.put("param1", "value1");
-        params.put("param2", "value2");
+        Map<String, Input> params = new HashMap<>();
+        params.put("param1", new Input("param1", "string", Input.Kind.PARAMETER, "value1", Optional.empty(), Optional.empty()));
+        params.put("param2", new Input("param2", "string", Input.Kind.PARAMETER, "value2", Optional.empty(), Optional.empty()));
         MockedStatic<ExecHelper> exec  = mockStatic(ExecHelper.class);
         exec.when(() -> ExecHelper.execute(anyString(), anyMap(), any())).thenReturn("");
 
@@ -236,8 +237,8 @@ public class TknCliTest {
 
     @Test
     public void checkRightArgsWhenStartingPipelineWithMultipleInputs() throws IOException {
-        Map<String, String> params = new HashMap<>();
-        params.put("param1", "value1");
+        Map<String, Input> params = new HashMap<>();
+        params.put("param1", new Input("param1", "string", Input.Kind.PARAMETER, "value1", Optional.empty(), Optional.empty()));
         Map<String, String> resources = new HashMap<>();
         resources.put("res1", "value1");
         resources.put("res2", "value2");
@@ -287,9 +288,9 @@ public class TknCliTest {
 
     @Test
     public void checkRightArgsWhenStartingTaskWithParameters() throws IOException {
-        Map<String, String> params = new HashMap<>();
-        params.put("param1", "value1");
-        params.put("param2", "value2");
+        Map<String, Input> params = new HashMap<>();
+        params.put("param1", new Input("param1", "string", Input.Kind.PARAMETER, "value1", Optional.empty(), Optional.empty()));
+        params.put("param2", new Input("param2", "string", Input.Kind.PARAMETER, "value2", Optional.empty(), Optional.empty()));
         MockedStatic<ExecHelper> exec  = mockStatic(ExecHelper.class);
         exec.when(() -> ExecHelper.execute(anyString(), anyMap(), any())).thenReturn("");
 
@@ -373,8 +374,8 @@ public class TknCliTest {
 
     @Test
     public void checkRightArgsWhenStartingTaskWithMultipleInputs() throws IOException {
-        Map<String, String> params = new HashMap<>();
-        params.put("param1", "value1");
+        Map<String, Input> params = new HashMap<>();
+        params.put("param1", new Input("param1", "string", Input.Kind.PARAMETER, "value1", Optional.empty(), Optional.empty()));
         Map<String, String> inputResources = new HashMap<>();
         inputResources.put("res1", "value1");
         inputResources.put("res2", "value2");
@@ -424,9 +425,9 @@ public class TknCliTest {
 
     @Test
     public void checkRightArgsWhenStartingClusterTaskWithParameters() throws IOException {
-        Map<String, String> params = new HashMap<>();
-        params.put("param1", "value1");
-        params.put("param2", "value2");
+        Map<String, Input> params = new HashMap<>();
+        params.put("param1", new Input("param1", "string", Input.Kind.PARAMETER, "value1", Optional.empty(), Optional.empty()));
+        params.put("param2", new Input("param2", "string", Input.Kind.PARAMETER, "value2", Optional.empty(), Optional.empty()));
         MockedStatic<ExecHelper> exec  = mockStatic(ExecHelper.class);
         exec.when(() -> ExecHelper.execute(anyString(), anyMap(), any())).thenReturn("");
 
@@ -510,8 +511,8 @@ public class TknCliTest {
 
     @Test
     public void checkRightArgsWhenStartingClusterTaskWithMultipleInputs() throws IOException {
-        Map<String, String> params = new HashMap<>();
-        params.put("param1", "value1");
+        Map<String, Input> params = new HashMap<>();
+        params.put("param1", new Input("param1", "string", Input.Kind.PARAMETER, "value1", Optional.empty(), Optional.empty()));
         Map<String, String> inputResources = new HashMap<>();
         inputResources.put("res1", "value1");
         inputResources.put("res2", "value2");


### PR DESCRIPTION
it resolves #313 

I am quite unsure the empty array in yaml is converted correctly but i copied what tekton does. Basically if you pass an empty array to the array param, the pipeline/task will be run like this

```
- name: values
    value:
    - ""
```
which for me is not an empty array but an array with an empty string as first value. Maybe something to ask to the tekton team.

Other thing to think about is if we want to allow users to start pipelines/tasks with empty string parameters.
With this patch only array parameter accepts an empty value, in a string param the empty value is considered an error.
WDYT? @jeffmaury If we consider that there could be a default value as an empty string it makes sense to remove this check