### PR TITLE
fix pipeline preview when value is too long (#314)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/BaseWizard.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/BaseWizard.java
@@ -136,7 +136,9 @@ public abstract class BaseWizard extends DialogWrapper {
         previewTextArea = new JTextArea();
         previewTextArea.setEditable(false);
         previewTextArea.setBorder(MARGIN_10);
+        previewTextArea.setSize(new Dimension(300, 400));
         previewTextArea.setFont(TIMES_PLAIN_14);
+        previewTextArea.setLineWrap(true);
 
         JPanel previewPanel = new JPanel();
         previewPanel.add(previewTextArea);
@@ -230,9 +232,6 @@ public abstract class BaseWizard extends DialogWrapper {
 
             if (!UIUtil.isUnderDarcula()) {
                 myHelpButton.putClientProperty("JButton.buttonType", "help");
-            }
-            if (UIUtil.isUnderAquaLookAndFeel()) {
-                myHelpButton.setText("");
             }
 
             int index = 0;


### PR DESCRIPTION
it resolves #314 

Now values too long will be written as multilines.
![image](https://user-images.githubusercontent.com/49404737/104309477-853a7c00-54d2-11eb-8f55-78735e79e1bd.png)
