### PR TITLE
feat(UI): add find task references action (#259)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/DeleteAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/DeleteAction.java
@@ -180,7 +180,7 @@ public class DeleteAction extends TektonAction {
             List<RefUsage> usages = tkn.findTaskUsages(kind, name);
             return usages.size();
         } catch (IOException e) {
-            logger.warn(e.getLocalizedMessage());
+            logger.warn(e.getLocalizedMessage(), e);
             return 0;
         }
     }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/clustertask/FindClusterTaskRefAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/clustertask/FindClusterTaskRefAction.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.actions.clustertask;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.redhat.devtools.intellij.common.utils.ExecHelper;
+import com.redhat.devtools.intellij.common.utils.UIHelper;
+import com.redhat.devtools.intellij.tektoncd.actions.TektonAction;
+import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
+import com.redhat.devtools.intellij.tektoncd.tree.ClusterTaskNode;
+import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
+import com.redhat.devtools.intellij.tektoncd.ui.toolwindow.findusage.FindTaskRefPanelBuilder;
+import com.redhat.devtools.intellij.tektoncd.ui.toolwindow.findusage.RefUsage;
+import java.io.IOException;
+import java.util.List;
+import javax.swing.tree.TreePath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_CLUSTERTASK;
+
+public class FindClusterTaskRefAction extends TektonAction {
+    private static final Logger logger = LoggerFactory.getLogger(FindClusterTaskRefAction.class);
+
+    public FindClusterTaskRefAction() {
+        super(ClusterTaskNode.class);
+    }
+
+    @Override
+    public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Tkn tkncli) {
+        ParentableNode element = getElement(selected);
+        ExecHelper.submit(() -> {
+            try {
+                List<RefUsage> usages = tkncli.findTaskUsages(KIND_CLUSTERTASK, element.getName());
+                UIHelper.executeInUI(() -> FindTaskRefPanelBuilder.instance().build(anActionEvent.getProject(), KIND_CLUSTERTASK, element.getName(), usages));
+            } catch (IOException e) {
+                logger.warn(e.getLocalizedMessage());
+            }
+        });
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/clustertask/FindClusterTaskRefAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/clustertask/FindClusterTaskRefAction.java
@@ -43,7 +43,7 @@ public class FindClusterTaskRefAction extends TektonAction {
                 List<RefUsage> usages = tkncli.findTaskUsages(KIND_CLUSTERTASK, element.getName());
                 UIHelper.executeInUI(() -> FindTaskRefPanelBuilder.instance().build(anActionEvent.getProject(), KIND_CLUSTERTASK, element.getName(), usages));
             } catch (IOException e) {
-                logger.warn(e.getLocalizedMessage());
+                logger.warn(e.getLocalizedMessage(), e);
             }
         });
     }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/task/FindTaskRefAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/task/FindTaskRefAction.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.actions.task;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.redhat.devtools.intellij.common.utils.ExecHelper;
+import com.redhat.devtools.intellij.common.utils.UIHelper;
+import com.redhat.devtools.intellij.tektoncd.actions.TektonAction;
+import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
+import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
+import com.redhat.devtools.intellij.tektoncd.tree.TaskNode;
+import com.redhat.devtools.intellij.tektoncd.ui.toolwindow.findusage.FindTaskRefPanelBuilder;
+import com.redhat.devtools.intellij.tektoncd.ui.toolwindow.findusage.RefUsage;
+import java.io.IOException;
+import java.util.List;
+import javax.swing.tree.TreePath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_TASK;
+
+public class FindTaskRefAction extends TektonAction {
+    private static final Logger logger = LoggerFactory.getLogger(FindTaskRefAction.class);
+    public FindTaskRefAction() { super(TaskNode.class); }
+
+    @Override
+    public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Tkn tkncli) {
+        ParentableNode element = getElement(selected);
+        ExecHelper.submit(() -> {
+            try {
+                List<RefUsage> usages = tkncli.findTaskUsages(KIND_TASK, element.getName());
+                UIHelper.executeInUI(() -> FindTaskRefPanelBuilder.instance().build(anActionEvent.getProject(), KIND_TASK, element.getName(), usages));
+            } catch (IOException e) {
+                logger.warn(e.getLocalizedMessage());
+            }
+        });
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/task/FindTaskRefAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/task/FindTaskRefAction.java
@@ -14,11 +14,13 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.redhat.devtools.intellij.common.utils.ExecHelper;
 import com.redhat.devtools.intellij.common.utils.UIHelper;
 import com.redhat.devtools.intellij.tektoncd.actions.TektonAction;
+import com.redhat.devtools.intellij.tektoncd.telemetry.TelemetryService;
 import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
 import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TaskNode;
 import com.redhat.devtools.intellij.tektoncd.ui.toolwindow.findusage.FindTaskRefPanelBuilder;
 import com.redhat.devtools.intellij.tektoncd.ui.toolwindow.findusage.RefUsage;
+import com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder;
 import java.io.IOException;
 import java.util.List;
 import javax.swing.tree.TreePath;
@@ -27,6 +29,9 @@ import org.slf4j.LoggerFactory;
 
 
 import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_TASK;
+import static com.redhat.devtools.intellij.tektoncd.telemetry.TelemetryService.NAME_PREFIX_MISC;
+import static com.redhat.devtools.intellij.tektoncd.telemetry.TelemetryService.PROP_RESOURCE_KIND;
+import static com.redhat.devtools.intellij.telemetry.core.util.AnonymizeUtils.anonymizeResource;
 
 public class FindTaskRefAction extends TektonAction {
     private static final Logger logger = LoggerFactory.getLogger(FindTaskRefAction.class);
@@ -34,12 +39,19 @@ public class FindTaskRefAction extends TektonAction {
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Tkn tkncli) {
+        TelemetryMessageBuilder.ActionMessage telemetry = TelemetryService.instance()
+                .action(NAME_PREFIX_MISC + "find task references")
+                .property(PROP_RESOURCE_KIND, KIND_TASK);
         ParentableNode element = getElement(selected);
         ExecHelper.submit(() -> {
             try {
                 List<RefUsage> usages = tkncli.findTaskUsages(KIND_TASK, element.getName());
                 UIHelper.executeInUI(() -> FindTaskRefPanelBuilder.instance().build(anActionEvent.getProject(), KIND_TASK, element.getName(), usages));
+                telemetry.send();
             } catch (IOException e) {
+                telemetry
+                        .error(anonymizeResource(null, element.getNamespace(), e.getMessage()))
+                        .send();
                 logger.warn(e.getLocalizedMessage());
             }
         });

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/task/FindTaskRefAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/task/FindTaskRefAction.java
@@ -52,7 +52,7 @@ public class FindTaskRefAction extends TektonAction {
                 telemetry
                         .error(anonymizeResource(null, element.getNamespace(), e.getMessage()))
                         .send();
-                logger.warn(e.getLocalizedMessage());
+                logger.warn(e.getLocalizedMessage(), e);
             }
         });
     }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/TknAutoInsertHandler.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/completion/TknAutoInsertHandler.java
@@ -33,7 +33,7 @@ public class TknAutoInsertHandler implements InsertHandler<LookupElement> {
             String elementText = SnippetHelper.getBody(item.getLookupString());
             document.replaceString(startOffset, tailOffset, elementText);
         } catch (IOException ex) {
-            logger.warn("Error: " + ex.getLocalizedMessage());
+            logger.warn("Error: " + ex.getLocalizedMessage(), ex);
         }
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/Tkn.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/Tkn.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.intellij.tektoncd.tkn;
 
 import com.redhat.devtools.intellij.tektoncd.tkn.component.field.Workspace;
+import com.redhat.devtools.intellij.tektoncd.ui.toolwindow.findusage.RefUsage;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
@@ -260,6 +261,16 @@ public interface Tkn {
      * @throws IOException if communication errored
      */
     String getEventListenerYAML(String namespace, String eventListener) throws IOException;
+
+    /**
+     * Return all pipelines where the task is used
+     *
+     * @param kind the kind of task (task or clustertask)
+     * @param task the name of the task
+     * @return list of pipelines where the task is used
+     * @throws IOException if communication errored
+     */
+    List<RefUsage> findTaskUsages(String kind, String task) throws IOException;
 
     /**
      * Delete a list of pipelines
@@ -549,6 +560,17 @@ public interface Tkn {
      * @throws IOException if communication errored
      */
     void cancelTaskRun(String namespace, String taskRun) throws IOException;
+
+    /**
+     * Set a watch on Pipeline resource
+     *
+     * @param namespace the namespace to use
+     * @param pipeline the name of the pipeline
+     * @param watcher the watcher to call when a new event is received
+     * @return the watch object
+     * @throws IOException if communication errored
+     */
+    Watch watchPipeline(String namespace, String pipeline, Watcher<Pipeline> watcher) throws IOException;
 
     /**
      * Set a watch on Pipeline resources

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/tkn/TknCli.java
@@ -288,7 +288,7 @@ public class TknCli implements Tkn {
 
     @Override
     public  List<RefUsage> findTaskUsages(String kind, String resource) throws IOException {
-        String jsonPathExpr = "jsonpath=\"{range .items[*]}{@.metadata.name}|{range .spec.tasks[*]}{.taskRef.kind},{.taskRef.name}|{end}{end}\"";
+        String jsonPathExpr = "jsonpath=\\\"{range .items[*]}{@.metadata.name}|{range .spec.tasks[*]}{.taskRef.kind},{.taskRef.name}|{end}{end}\\\"";
         String result = ExecHelper.execute(command, envVars, "pipeline", "ls", "-n", getNamespace(), "-o", jsonPathExpr);
         String[] resultSplitted = result.replace("\"", "").split("\\|");
         List<RefUsage> usages = new ArrayList<>();

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/DeleteDialog.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/DeleteDialog.java
@@ -31,18 +31,18 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class DeleteDialog extends DialogWrapper{
-    private JCheckBox deleteResourcesChb;
+    private JCheckBox deleteRelatedResourcesChb;
     private JPanel myContentPanel;
     private JLabel deleteText;
     private GridBagConstraints gridBagConstraints;
-    private boolean deleteResources;
+    private boolean deleteRelatedResources;
 
     public DeleteDialog(Component parent, String title, String mainDeleteText, String deleteChkText) {
         super(null, parent, false, DialogWrapper.IdeModalityType.IDE);
         GridBagLayout gridBagLayout = new GridBagLayout();
         gridBagConstraints = new GridBagConstraints();
         this.myContentPanel = new JPanel(gridBagLayout);
-        this.deleteResources = false;
+        this.deleteRelatedResources = false;
 
         setTitle(title);
         fillContainer(mainDeleteText, deleteChkText);
@@ -59,12 +59,12 @@ public class DeleteDialog extends DialogWrapper{
 
     @Override
     protected void doOKAction() {
-        this.deleteResources = deleteResourcesChb.isSelected();
+        this.deleteRelatedResources = deleteRelatedResourcesChb != null ? deleteRelatedResourcesChb.isSelected() : false;
         super.doOKAction();
     }
 
-    public boolean hasToDeleteResources() {
-        return this.deleteResources;
+    public boolean hasToDeleteRelatedResources() {
+        return this.deleteRelatedResources;
     }
 
     @Nullable
@@ -95,9 +95,9 @@ public class DeleteDialog extends DialogWrapper{
         }
 
         if (!deleteChkText.isEmpty()) {
-            deleteResourcesChb = new JCheckBox(deleteChkText);
-            deleteResourcesChb.setSelected(SettingsState.getInstance().enableDeleteAllRelatedResourcesAsDefault);
-            addComponent(deleteResourcesChb, new EmptyBorder(5, 10, 10, 10), null, 0, 4, GridBagConstraints.NORTHWEST);
+            deleteRelatedResourcesChb = new JCheckBox(deleteChkText);
+            deleteRelatedResourcesChb.setSelected(SettingsState.getInstance().enableDeleteAllRelatedResourcesAsDefault);
+            addComponent(deleteRelatedResourcesChb, new EmptyBorder(5, 10, 10, 10), null, 0, 4, GridBagConstraints.NORTHWEST);
         }
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/hub/HubModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/hub/HubModel.java
@@ -96,7 +96,7 @@ public class HubModel {
         try {
             resApi.resourceQueryAsync(query, kinds, tags, null, null, callback);
         } catch (ApiException e) {
-            logger.warn(e.getLocalizedMessage());
+            logger.warn(e.getLocalizedMessage(), e);
         }
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/toolwindow/WindowToolFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/toolwindow/WindowToolFactory.java
@@ -8,7 +8,7 @@
  * Contributors:
  * Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package com.redhat.devtools.intellij.tektoncd;
+package com.redhat.devtools.intellij.tektoncd.ui.toolwindow;
 
 import com.intellij.ide.util.treeView.AbstractTreeStructure;
 import com.intellij.ide.util.treeView.NodeRenderer;
@@ -25,6 +25,7 @@ import com.intellij.ui.content.ContentFactory;
 import com.intellij.ui.tree.AsyncTreeModel;
 import com.intellij.ui.tree.StructureTreeModel;
 import com.intellij.ui.treeStructure.Tree;
+import com.redhat.devtools.intellij.tektoncd.Constants;
 import com.redhat.devtools.intellij.tektoncd.listener.TreeDoubleClickListener;
 import com.redhat.devtools.intellij.tektoncd.listener.TreePopupMenuListener;
 import com.redhat.devtools.intellij.tektoncd.tree.MutableTektonModelSynchronizer;

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/toolwindow/findusage/FindTaskRefPanelBuilder.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/toolwindow/findusage/FindTaskRefPanelBuilder.java
@@ -185,7 +185,7 @@ public class FindTaskRefPanelBuilder {
                     VirtualFile vf = TektonVirtualFileManager.getInstance(project).findResource(ref.getNamespace(), ref.getKind(), ref.getName());
                     VirtualFileHelper.openVirtualFileInEditor(project, ref.getNamespace(), ref.getName(), ((LightVirtualFile) vf).getContent().toString(), ref.getKind(), false);
                 } catch (IOException ex) {
-                    logger.warn(ex.getLocalizedMessage());
+                    logger.warn(ex.getLocalizedMessage(), e);
                 }
 
             }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/toolwindow/findusage/FindTaskRefPanelBuilder.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/toolwindow/findusage/FindTaskRefPanelBuilder.java
@@ -143,7 +143,7 @@ public class FindTaskRefPanelBuilder {
     private TreeSelectionListener getTreeSelectionListener(Project project) {
         return e -> {
             LabelAndIconDescriptor node = getLastSelectedNode();
-            if (node.getElement() instanceof RefUsage) {
+            if (node != null && node.getElement() instanceof RefUsage) {
                 fillEditorPanel(project, (RefUsage) node.getElement());
             } else {
                 fillEditorPanelWithMessage();
@@ -157,7 +157,7 @@ public class FindTaskRefPanelBuilder {
             public void mouseClicked(MouseEvent e) {
                 if (SwingUtilities.isRightMouseButton(e)) {
                     LabelAndIconDescriptor node = getLastSelectedNode();
-                    if (node.getElement() instanceof RefUsage) {
+                    if (node != null && node.getElement() instanceof RefUsage) {
                         getContextMenu(project).show(e.getComponent(), e.getX(), e.getY());
                     }
                 }
@@ -179,7 +179,7 @@ public class FindTaskRefPanelBuilder {
     private ActionListener getJumpSourceAction(Project project) {
         return e -> {
             LabelAndIconDescriptor node = getLastSelectedNode();
-            if (node.getElement() instanceof RefUsage) {
+            if (node != null && node.getElement() instanceof RefUsage) {
                 RefUsage ref = (RefUsage) node.getElement();
                 try {
                     VirtualFile vf = TektonVirtualFileManager.getInstance(project).findResource(ref.getNamespace(), ref.getKind(), ref.getName());
@@ -194,8 +194,11 @@ public class FindTaskRefPanelBuilder {
 
     private LabelAndIconDescriptor getLastSelectedNode() {
         Object selection = tree.getLastSelectedPathComponent();
-        DefaultMutableTreeNode defaultMutableTreeNode = (DefaultMutableTreeNode)selection;
-        return (LabelAndIconDescriptor) defaultMutableTreeNode.getUserObject();
+        if (selection == null || !(selection instanceof DefaultMutableTreeNode)) {
+            return null;
+        }
+        Object userObject = ((DefaultMutableTreeNode)selection).getUserObject();
+        return userObject == null ? null : (LabelAndIconDescriptor) userObject;
     }
 
     private JComponent buildEditorPanel() {

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/toolwindow/findusage/FindTaskRefPanelBuilder.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/toolwindow/findusage/FindTaskRefPanelBuilder.java
@@ -225,7 +225,7 @@ public class FindTaskRefPanelBuilder {
             PsiAwareTextEditorImpl editor = new PsiAwareTextEditorImpl(project, vf, TextEditorProvider.getInstance());
             updateEditorPanel(new JBScrollPane(editor.getComponent()));
         } catch (IOException e) {
-            logger.warn(e.getLocalizedMessage());
+            logger.warn(e.getLocalizedMessage(), e);
         }
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/toolwindow/findusage/FindTaskRefPanelBuilder.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/toolwindow/findusage/FindTaskRefPanelBuilder.java
@@ -1,0 +1,252 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.ui.toolwindow.findusage;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.fileEditor.impl.text.PsiAwareTextEditorImpl;
+import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Divider;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.testFramework.LightVirtualFile;
+import com.intellij.ui.OnePixelSplitter;
+import com.intellij.ui.components.JBScrollPane;
+import com.intellij.ui.content.Content;
+import com.intellij.ui.content.ContentFactory;
+import com.intellij.ui.treeStructure.Tree;
+import com.intellij.util.ui.UIUtil;
+import com.intellij.util.ui.tree.TreeUtil;
+import com.redhat.devtools.intellij.common.tree.LabelAndIconDescriptor;
+import com.redhat.devtools.intellij.tektoncd.utils.TektonVirtualFileManager;
+import com.redhat.devtools.intellij.tektoncd.utils.VirtualFileHelper;
+import java.awt.BorderLayout;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import javax.swing.event.TreeSelectionListener;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreeCellRenderer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+import static com.redhat.devtools.intellij.tektoncd.ui.UIConstants.SEARCH_FIELD_BORDER_COLOR;
+
+public class FindTaskRefPanelBuilder {
+    private static final Logger logger = LoggerFactory.getLogger(FindTaskRefPanelBuilder.class);
+    private final static String FINDTASKREFTOOLWINDOW_ID = "FindTaskRef";
+    private static FindTaskRefPanelBuilder instance;
+    private JPanel editorPanel;
+    private JTree tree;
+    private JPopupMenu contextMenu;
+
+    private FindTaskRefPanelBuilder() {}
+
+    public static FindTaskRefPanelBuilder instance() {
+        if (instance == null) {
+            instance = new FindTaskRefPanelBuilder();
+        }
+        return instance;
+    }
+
+    public void build(Project project, String kind, String task, List<RefUsage> usages) {
+        ToolWindow window = ToolWindowManager.getInstance(project).getToolWindow(FINDTASKREFTOOLWINDOW_ID);
+
+        ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
+        Content panel = contentFactory.createContent(buildTabPanel(project, usages), "Usages of " + kind + " " + task, true);
+        panel.setCloseable(true);
+        window.getContentManager().addContent(panel);
+        window.getContentManager().setSelectedContent(panel);
+
+        window.setToHideOnEmptyContent(true);
+        window.setAvailable(true, null);
+        window.activate(null);
+        window.show(null);
+    }
+
+    public JComponent buildTabPanel(Project project, List<RefUsage> usages) {
+        OnePixelSplitter tabPanel = new OnePixelSplitter(false, 0.37F) {
+            protected Divider createDivider() {
+                Divider divider = super.createDivider();
+                divider.setBackground(SEARCH_FIELD_BORDER_COLOR);
+                return divider;
+            }
+        };
+        tabPanel.setFirstComponent(buildUsagesTree(project, usages));
+        tabPanel.setSecondComponent(buildEditorPanel());
+        return tabPanel;
+    }
+
+    private JComponent buildUsagesTree(Project project, List<RefUsage> usages) {
+        DefaultTreeModel model = getModel(project, usages);
+        tree = new Tree(model);
+        tree.setCellRenderer(getTreeCellRenderer());
+        tree.addTreeSelectionListener(getTreeSelectionListener(project));
+        tree.addMouseListener(getMouseListener(project));
+        tree.setVisible(true);
+        return new JBScrollPane(tree);
+    }
+
+    private DefaultTreeModel getModel(Project project, List<RefUsage> usages) {
+        int totalUsages = usages.stream().map(ref -> ref.getOccurrence()).reduce(0, Integer::sum);
+        DefaultMutableTreeNode root = new DefaultMutableTreeNode(new LabelAndIconDescriptor(project, null, "Find Usages", getUsageText(totalUsages, false), null, null));
+        DefaultTreeModel model = new DefaultTreeModel(root);
+
+        Map<String, List<RefUsage>> kindPerRefs = usages.stream().collect(Collectors.groupingBy(e -> e.getKind(), Collectors.toList()));
+        kindPerRefs.entrySet().stream().forEach(entry -> {
+            int totalUsagesByKind = entry.getValue().stream().map(ref -> ref.getOccurrence()).reduce(0, Integer::sum);
+            DefaultMutableTreeNode kindNode = new DefaultMutableTreeNode(new LabelAndIconDescriptor(project, null, entry.getKey(), getUsageText(totalUsagesByKind, true), null, null));
+            model.insertNodeInto(kindNode, root, 0);
+            entry.getValue().stream().forEach(refUsage -> {
+                DefaultMutableTreeNode refNode = new DefaultMutableTreeNode(new LabelAndIconDescriptor(project, refUsage, refUsage.getName(), getUsageText(refUsage.getOccurrence(), true), null, null));
+                model.insertNodeInto(refNode, kindNode, 0);
+            });
+        });
+
+        return model;
+    }
+
+    private TreeCellRenderer getTreeCellRenderer() {
+        return (tree1, value, selected, expanded, leaf, row, hasFocus) -> {
+            Object node = TreeUtil.getUserObject(value);
+            if (node instanceof LabelAndIconDescriptor) {
+                ((LabelAndIconDescriptor) node).update();
+                return createLabel(((LabelAndIconDescriptor) node).getPresentation().getPresentableText(), ((LabelAndIconDescriptor) node).getPresentation().getLocationString());
+            }
+            return null;
+        };
+    }
+
+    private TreeSelectionListener getTreeSelectionListener(Project project) {
+        return e -> {
+            LabelAndIconDescriptor node = getLastSelectedNode();
+            if (node.getElement() instanceof RefUsage) {
+                fillEditorPanel(project, (RefUsage) node.getElement());
+            } else {
+                fillEditorPanelWithMessage();
+            }
+        };
+    }
+
+    private MouseListener getMouseListener(Project project) {
+        return new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                if (SwingUtilities.isRightMouseButton(e)) {
+                    LabelAndIconDescriptor node = getLastSelectedNode();
+                    if (node.getElement() instanceof RefUsage) {
+                        getContextMenu(project).show(e.getComponent(), e.getX(), e.getY());
+                    }
+                }
+            }
+        };
+    }
+
+    private JPopupMenu getContextMenu(Project project) {
+        if (contextMenu == null) {
+            contextMenu = new JPopupMenu();
+            JMenuItem item = new JMenuItem("Jump to Source", AllIcons.Actions.EditSource);
+            item.addActionListener(getJumpSourceAction(project));
+            contextMenu.add(item);
+        }
+
+        return contextMenu;
+    }
+
+    private ActionListener getJumpSourceAction(Project project) {
+        return e -> {
+            LabelAndIconDescriptor node = getLastSelectedNode();
+            if (node.getElement() instanceof RefUsage) {
+                RefUsage ref = (RefUsage) node.getElement();
+                try {
+                    VirtualFile vf = TektonVirtualFileManager.getInstance(project).findResource(ref.getNamespace(), ref.getKind(), ref.getName());
+                    VirtualFileHelper.openVirtualFileInEditor(project, ref.getNamespace(), ref.getName(), ((LightVirtualFile) vf).getContent().toString(), ref.getKind(), false);
+                } catch (IOException ex) {
+                    logger.warn(ex.getLocalizedMessage());
+                }
+
+            }
+        };
+    }
+
+    private LabelAndIconDescriptor getLastSelectedNode() {
+        Object selection = tree.getLastSelectedPathComponent();
+        DefaultMutableTreeNode defaultMutableTreeNode = (DefaultMutableTreeNode)selection;
+        return (LabelAndIconDescriptor) defaultMutableTreeNode.getUserObject();
+    }
+
+    private JComponent buildEditorPanel() {
+        editorPanel = new JPanel(new BorderLayout());
+        fillEditorPanelWithMessage();
+        return editorPanel;
+    }
+
+    private void fillEditorPanelWithMessage() {
+        JLabel infoMessage = new JLabel("Select usage to preview");
+        infoMessage.setEnabled(false);
+        infoMessage.setHorizontalAlignment(JLabel.CENTER);
+        updateEditorPanel(infoMessage);
+    }
+
+    private void fillEditorPanel(Project project, RefUsage usage) {
+        if (project == null || usage == null) {
+            fillEditorPanelWithMessage();
+        }
+
+        try {
+            VirtualFile vf = TektonVirtualFileManager.getInstance(project).findResource(usage.getNamespace(), usage.getKind(), usage.getName());
+            vf.setWritable(false);
+            PsiAwareTextEditorImpl editor = new PsiAwareTextEditorImpl(project, vf, TextEditorProvider.getInstance());
+            updateEditorPanel(new JBScrollPane(editor.getComponent()));
+        } catch (IOException e) {
+            logger.warn(e.getLocalizedMessage());
+        }
+    }
+
+    private void updateEditorPanel(JComponent component) {
+        editorPanel.removeAll();
+        editorPanel.add(component, BorderLayout.CENTER);
+        editorPanel.revalidate();
+        editorPanel.repaint();
+    }
+
+    private String getUsageText(int occurrences, boolean emptyIfZero) {
+        if (emptyIfZero && occurrences == 0) {
+            return "";
+        }
+        return occurrences + " " + (occurrences == 1 ? "usage" : "usages");
+    }
+
+    private JComponent createLabel(String name, String location) {
+        String label = "<html>" + name;
+        if (!location.isEmpty()) {
+            String rgb = "rgb(" + UIUtil.getLabelDisabledForeground().getRed() + ", " + UIUtil.getLabelDisabledForeground().getGreen() + ", " + UIUtil.getLabelDisabledForeground().getBlue() + ")";
+            label += " <span style=\"color: " + rgb + "\">" + location + "</span>";
+        }
+        label += "</html>";
+        return new JLabel(label);
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/toolwindow/findusage/FindWindowToolFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/toolwindow/findusage/FindWindowToolFactory.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.ui.toolwindow.findusage;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowFactory;
+import org.jetbrains.annotations.NotNull;
+
+public class FindWindowToolFactory implements ToolWindowFactory {
+    @Override
+    public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
+        toolWindow.setIcon(AllIcons.Actions.Search);
+        toolWindow.setStripeTitle("Tekton Find");
+    }
+
+    @Override
+    public boolean isDoNotActivateOnStart() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldBeAvailable(@NotNull Project project) {
+        return false;
+    }
+
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/toolwindow/findusage/RefUsage.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/toolwindow/findusage/RefUsage.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.ui.toolwindow.findusage;
+
+public class RefUsage {
+    private String namespace, name, kind;
+    private int occurrence;
+
+    public RefUsage(String namespace, String name, String kind) {
+        this.namespace = namespace;
+        this.name = name;
+        this.kind = kind;
+        this.occurrence = 1;
+    }
+
+    public String getNamespace() { return namespace; }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public int getOccurrence() {
+        return occurrence;
+    }
+
+    public void incremetOccurrence() {
+        occurrence += 1;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/BaseWizard.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/wizard/BaseWizard.java
@@ -54,6 +54,8 @@ import javax.swing.JTextArea;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 import static com.redhat.devtools.intellij.tektoncd.ui.UIConstants.BLUE;
@@ -63,6 +65,7 @@ import static com.redhat.devtools.intellij.tektoncd.ui.UIConstants.TIMES_PLAIN_1
 
 public abstract class BaseWizard extends DialogWrapper {
 
+    private static final Logger logger = LoggerFactory.getLogger(BaseWizard.class);
     private String myTitle;
     protected List<BaseStep> mySteps;
     private int myCurrentStep;
@@ -481,7 +484,7 @@ public abstract class BaseWizard extends DialogWrapper {
         try {
             preview = new YAMLMapper().writeValueAsString(YAMLBuilder.createRun(model));
         } catch (IOException e) {
-            //logger.warn("Error: " + e.getLocalizedMessage());
+            logger.warn("Error: " + e.getLocalizedMessage(), e);
         }
         previewTextArea.setText(preview);
     }

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/TektonVirtualFileManager.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/TektonVirtualFileManager.java
@@ -17,12 +17,10 @@ import com.intellij.testFramework.LightVirtualFile;
 import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
 import gnu.trove.THashMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 import java.io.IOException;
 import java.util.Map;
-
-import io.fabric8.kubernetes.client.WatcherException;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -120,7 +118,7 @@ public class TektonVirtualFileManager {
         } else if (kind.equalsIgnoreCase(KIND_PIPELINERUN)){
             content = tkncli.getPipelineRunYAML(namespace, resourceName);
         }
-        return new LightVirtualFile(resourceName, content);
+        return new LightVirtualFile(resourceName + ".yaml", content);
     }
 
     private String getId(String namespace, String kind, String resourceName) {

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/WatchHandler.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/WatchHandler.java
@@ -52,6 +52,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
+import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_PIPELINE;
 import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_PIPELINERUNS;
 import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_TASK;
 import static com.redhat.devtools.intellij.tektoncd.Constants.KIND_TASKRUNS;
@@ -83,7 +84,9 @@ public class WatchHandler {
         }
 
         try {
-            if (kind.equalsIgnoreCase(KIND_TASK)) {
+            if (kind.equalsIgnoreCase(KIND_PIPELINE)) {
+                watch = tkn.watchPipeline(namespace, resourceName, watcher);
+            } else if (kind.equalsIgnoreCase(KIND_TASK)) {
                 watch = tkn.watchTask(namespace, resourceName, watcher);
             }
             wn = new WatchNodes(watch);

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -160,7 +160,8 @@
                                        implementation="com.redhat.devtools.intellij.tektoncd.listener.SaveInEditorListener" order="first" />
     <completion.contributor id="com.redhat.devtools.intellij.tektoncd.completion.DictionaryContributor"
                             language="any" implementationClass="com.redhat.devtools.intellij.tektoncd.completion.DictionaryContributor"/>
-    <toolWindow id="Tekton" anchor="left" factoryClass="com.redhat.devtools.intellij.tektoncd.WindowToolFactory" icon="/images/cluster.png"/>
+    <toolWindow id="Tekton" anchor="left" factoryClass="com.redhat.devtools.intellij.tektoncd.ui.toolwindow.WindowToolFactory" icon="/images/cluster.png"/>
+      <toolWindow id="FindTaskRef" anchor="bottom" factoryClass="com.redhat.devtools.intellij.tektoncd.ui.toolwindow.findusage.FindWindowToolFactory" canCloseContents="true" />
     <fileEditorProvider id="com.redhat.devtools.intellij.tektoncd.editors.TektonFileEditorProvider"
                         implementation="com.redhat.devtools.intellij.tektoncd.ui.editors.TektonFileEditorProvider"/>
     <localInspection id="com.redhat.devtools.intellij.tektoncd.inspector.VariableReferencesInspector"
@@ -189,6 +190,8 @@
       <action id="com.redhat.devtools.intellij.tektoncd.action.StartAction" class="com.redhat.devtools.intellij.tektoncd.actions.StartAction" text="Start"/>
       <action id="com.redhat.devtools.intellij.tektoncd.action.MirrorStartAction" class="com.redhat.devtools.intellij.tektoncd.actions.MirrorStartAction" text="Mirror Start"/>
       <action id="com.redhat.devtools.intellij.tektoncd.action.StartLastRunAction" class="com.redhat.devtools.intellij.tektoncd.actions.StartLastRunAction" text="Start Last Run"/>
+      <action id="com.redhat.devtools.intellij.tektoncd.actions.task.FindTaskRefAction" class="com.redhat.devtools.intellij.tektoncd.actions.task.FindTaskRefAction" text="Find Usages" />
+      <action id="com.redhat.devtools.intellij.tektoncd.actions.clustertask.FindClusterTaskRefAction" class="com.redhat.devtools.intellij.tektoncd.actions.clustertask.FindClusterTaskRefAction" text="Find Usages" />
       <action id="com.redhat.devtools.intellij.tektoncd.action.CreateTaskRunTemplateAction" class="com.redhat.devtools.intellij.tektoncd.actions.task.CreateTaskRunTemplateAction" text="Create Run Template"/>
       <action id="com.redhat.devtools.intellij.tektoncd.action.AddTriggerAction" class="com.redhat.devtools.intellij.tektoncd.actions.AddTriggerAction" text="Add Trigger"/>
       <action id="com.redhat.devtools.intellij.tektoncd.action.FollowLogsAction" class="com.redhat.devtools.intellij.tektoncd.actions.logs.FollowLogsAction" text="Follow Logs"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -161,7 +161,7 @@
     <completion.contributor id="com.redhat.devtools.intellij.tektoncd.completion.DictionaryContributor"
                             language="any" implementationClass="com.redhat.devtools.intellij.tektoncd.completion.DictionaryContributor"/>
     <toolWindow id="Tekton" anchor="left" factoryClass="com.redhat.devtools.intellij.tektoncd.ui.toolwindow.WindowToolFactory" icon="/images/cluster.png"/>
-      <toolWindow id="FindTaskRef" anchor="bottom" factoryClass="com.redhat.devtools.intellij.tektoncd.ui.toolwindow.findusage.FindWindowToolFactory" canCloseContents="true" />
+    <toolWindow id="FindTaskRef" anchor="bottom" factoryClass="com.redhat.devtools.intellij.tektoncd.ui.toolwindow.findusage.FindWindowToolFactory" canCloseContents="true" />
     <fileEditorProvider id="com.redhat.devtools.intellij.tektoncd.editors.TektonFileEditorProvider"
                         implementation="com.redhat.devtools.intellij.tektoncd.ui.editors.TektonFileEditorProvider"/>
     <localInspection id="com.redhat.devtools.intellij.tektoncd.inspector.VariableReferencesInspector"
@@ -190,8 +190,8 @@
       <action id="com.redhat.devtools.intellij.tektoncd.action.StartAction" class="com.redhat.devtools.intellij.tektoncd.actions.StartAction" text="Start"/>
       <action id="com.redhat.devtools.intellij.tektoncd.action.MirrorStartAction" class="com.redhat.devtools.intellij.tektoncd.actions.MirrorStartAction" text="Mirror Start"/>
       <action id="com.redhat.devtools.intellij.tektoncd.action.StartLastRunAction" class="com.redhat.devtools.intellij.tektoncd.actions.StartLastRunAction" text="Start Last Run"/>
-      <action id="com.redhat.devtools.intellij.tektoncd.actions.task.FindTaskRefAction" class="com.redhat.devtools.intellij.tektoncd.actions.task.FindTaskRefAction" text="Find Usages" />
-      <action id="com.redhat.devtools.intellij.tektoncd.actions.clustertask.FindClusterTaskRefAction" class="com.redhat.devtools.intellij.tektoncd.actions.clustertask.FindClusterTaskRefAction" text="Find Usages" />
+      <action id="com.redhat.devtools.intellij.tektoncd.action.task.FindTaskRefAction" class="com.redhat.devtools.intellij.tektoncd.actions.task.FindTaskRefAction" text="Find Usages" />
+      <action id="com.redhat.devtools.intellij.tektoncd.action.clustertask.FindClusterTaskRefAction" class="com.redhat.devtools.intellij.tektoncd.actions.clustertask.FindClusterTaskRefAction" text="Find Usages" />
       <action id="com.redhat.devtools.intellij.tektoncd.action.CreateTaskRunTemplateAction" class="com.redhat.devtools.intellij.tektoncd.actions.task.CreateTaskRunTemplateAction" text="Create Run Template"/>
       <action id="com.redhat.devtools.intellij.tektoncd.action.AddTriggerAction" class="com.redhat.devtools.intellij.tektoncd.actions.AddTriggerAction" text="Add Trigger"/>
       <action id="com.redhat.devtools.intellij.tektoncd.action.FollowLogsAction" class="com.redhat.devtools.intellij.tektoncd.actions.logs.FollowLogsAction" text="Follow Logs"/>


### PR DESCRIPTION
it resolves #259 .

This patch adds the action to find references of a task/clustertask inside the cluster. 
A tool window is opened in the bottom consisting of a tree that contains all resources that contains a reference to the task/ct. Each resource can be opened in read-only from there and also in the editor, in the classic way, using the `jump to source` action (as IJ does for its `Find Usages` action).

In the delete dialog there is a message to inform the user whenever the resource to be deleted is used somewhere.

![findtaskref](https://user-images.githubusercontent.com/49404737/112828011-70ac5f80-908f-11eb-8275-f0173a245f25.gif)
