### PR TITLE
chore: bump conventional changelog to support skip-release scope

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Simple conventional changelog
-        uses: lstocchi/simple-conventional-changelog@0.0.6
+        uses: lstocchi/simple-conventional-changelog@0.0.11
         id: changelog
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/draftGenerator.yml
+++ b/.github/workflows/draftGenerator.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Simple conventional changelog
-        uses: lstocchi/simple-conventional-changelog@0.0.9
+        uses: lstocchi/simple-conventional-changelog@0.0.11
         id: changelog
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
       - name: Simple conventional changelog
-        uses: lstocchi/simple-conventional-changelog@0.0.6
+        uses: lstocchi/simple-conventional-changelog@0.0.11
         id: changelog
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This resolves what we discussed weeks ago about skipping commits when releasing. @jeffmaury 

The new `conventional-changelog` GH action has a special scope `skip-release` which prevents a commit from being inserted in the changelog. 

So if you use something like `chore(skip-release): commit title here` the commit won't appear in the changelog of the next release.

cc @adietish @sbouchet 