### PR TITLE
fix: error when starting task in debug (#518)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/YAMLBuilder.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/utils/YAMLBuilder.java
@@ -394,7 +394,7 @@ public class YAMLBuilder {
         ObjectNode run = YAMLBuilder.convertToObjectNode(resourceAsYAML);
         ObjectNode breakpoint = YAMLBuilder.createBreakpointSection();
         ((ObjectNode)run.get("spec")).set("debug", breakpoint);
-        return YAMLHelper.JSONToYAML(run);
+        return YAMLHelper.JSONToYAML(run, false);
     }
 
     public static ObjectNode createTriggerTemplate(String name, String apiVersion, List<String> params, List<ObjectNode> runs) {


### PR DESCRIPTION
it resolves #518 

The problem was that i had number inputs and by minimizing quotes they were written as `value:1` instead of `value"1"`