### PR TITLE
fix: prevent plugin exception classloader is not equal to plugin's one

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/toolwindow/WindowToolFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/ui/toolwindow/WindowToolFactory.java
@@ -65,7 +65,7 @@ public class WindowToolFactory implements ToolWindowFactory {
             tree.setCellRenderer(new NodeRenderer());
             ActionManager actionManager = ActionManager.getInstance();
             ActionGroup group = (ActionGroup)actionManager.getAction("com.redhat.devtools.intellij.tektoncd.tree");
-            PopupHandler.installPopupHandler(tree, group, ActionPlaces.UNKNOWN, actionManager, new TektonTreePopupMenuListener());
+            PopupHandler.installPopupHandler(tree, group, ActionPlaces.POPUP, actionManager, new TektonTreePopupMenuListener());
 
             new TektonTreeDoubleClickListener(tree);
 

--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/validation/TektonSchemasProviderFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/validation/TektonSchemasProviderFactory.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *  Copyright (c) 2022 Red Hat, Inc.
+ *  Distributed under license by Red Hat, Inc. All rights reserved.
+ *  This program is made available under the terms of the
+ *  Eclipse Public License v2.0 which accompanies this distribution,
+ *  and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ *  Contributors:
+ *  Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.tektoncd.validation;
+
+import com.redhat.devtools.intellij.common.validation.SchemasProviderFactory;
+
+public class TektonSchemasProviderFactory extends SchemasProviderFactory {
+    public TektonSchemasProviderFactory() {
+        super();
+    }
+}

--- a/src/main/resources/META-INF/plugin-json.xml
+++ b/src/main/resources/META-INF/plugin-json.xml
@@ -1,5 +1,5 @@
 <idea-plugin>
     <extensions defaultExtensionNs="JavaScript.JsonSchema">
-        <ProviderFactory implementation="com.redhat.devtools.intellij.common.validation.SchemasProviderFactory"/>
+        <ProviderFactory implementation="com.redhat.devtools.intellij.tektoncd.validation.TektonSchemasProviderFactory"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
Signed-off-by: Luca Stocchi <lstocchi@redhat.com>