### PR TITLE
fix: edit is visible clause to prevent fatal error (#582)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/AddTriggerAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/tektoncd/actions/AddTriggerAction.java
@@ -26,7 +26,6 @@ import com.redhat.devtools.intellij.tektoncd.tkn.Tkn;
 import com.redhat.devtools.intellij.tektoncd.tree.ParentableNode;
 import com.redhat.devtools.intellij.tektoncd.tree.PipelineNode;
 import com.redhat.devtools.intellij.tektoncd.tree.TaskNode;
-import com.redhat.devtools.intellij.tektoncd.tree.TektonRootNode;
 import com.redhat.devtools.intellij.tektoncd.ui.wizard.addtrigger.AddTriggerWizard;
 import com.redhat.devtools.intellij.tektoncd.utils.CRDHelper;
 import com.redhat.devtools.intellij.tektoncd.utils.SnippetHelper;
@@ -69,9 +68,8 @@ public class AddTriggerAction extends TektonAction {
     @Override
     public boolean isVisible(Object selected) {
         // if triggers are not installed, don't show this action
-        return (!(selected instanceof TektonRootNode)
-                && ((ParentableNode)selected).getRoot().getTkn().isTektonTriggersAware()
-                && (selected instanceof PipelineNode || selected instanceof TaskNode));
+        return ((selected instanceof PipelineNode || selected instanceof TaskNode)
+                && ((ParentableNode)selected).getRoot().getTkn().isTektonTriggersAware());
     }
 
     @Override


### PR DESCRIPTION
it resolves #582 . I wasn't able to replicate it but the classcast error comes from the `isVisible` method. This should prevent the fatal error from happening again :crossed_fingers: 