### PR TITLE
fix: remove overview word from plugin description (#630)

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -6,7 +6,6 @@
 
   <description><![CDATA[
       <img src="https://raw.githubusercontent.com/redhat-developer/intellij-tekton/main/src/main/resources/images/tekton.png" width="32" height="32"/>
-      <h2>Overview</h2>
       <p>A plugin for interacting with Tekton Pipelines using a local or remote instance of Kubernetes or OpenShift clusters providing a streamlined developer experience. This extension is currently in Preview Mode.</p>
       <p>To run the instance of a Kubernetes cluster locally, developers can use <a href="https://github.com/kubernetes/minikube">Minikube</a>.</p>
       <p>To run the instance of an OpenShift cluster locally, developers can use <a href="https://developers.redhat.com/products/openshift-local/overview">OpenShift Local</a> / <a href="https://developers.redhat.com/products/cdk/download/">CDK</a> / <a href="https://github.com/minishift/minishift/releases">minishift</a>. Currently all clusters are supported, but with some limitations for OpenShift Online Pro where additional storage might be required to create more than two components.</p>


### PR DESCRIPTION
it resolves #630 