### PR TITLE
chore(skip-release): bump sinceIdea to IU-2022.3

### DIFF
--- a/.github/workflows/IJ.yml
+++ b/.github/workflows/IJ.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        IJ: [IU-2022.2, IU-2022.3, IU-2023.1, IU-2023.2, , IU-2023.3]
+        IJ: [IU-2022.3, IU-2023.1, IU-2023.2, IU-2023.3, IU-2024.1]
 
     steps:
     - uses: actions/checkout@v2

--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,5 @@
 buildscript {
-    /*
-     * for more complex conversion ideaVersion -> sinceIdeaBuild
-     * see https://github.com/rhdunn/xquery-intellij-plugin/blob/master/build.gradle#L1-L47
-     */
-    def since = ideaVersion =~ /I.-20(\d\d)\.([1-3])(\.\d+)?$/
-    if (since.matches()) {
-        ext.sinceIdeaBuild = "${since.group(1)}${since.group(2)}".toInteger()
-    } else {
-        ext.sinceIdeaBuild = 0
-    }
-
-    if (ext.sinceIdeaBuild.toInteger() >= 223) {
-        ext.java_version = "17"
-    } else {
-        ext.java_version = "11"
-    }
+    ext.java_version = "17"
 }
 
 
@@ -40,7 +25,7 @@ configurations {
     }
 }
 
-def versionsMap = ['IU-2022.1':'221.5080.1', 'IU-2022.2':'222.3345.16', 'IU-2022.3':'223.7571.175', 'IU-2023.1':'231.8109.91', 'IU-2023.2':'232.8660.158', 'IU-2023.3':'233.11799.296']
+def versionsMap = ['IU-2022.3':'223.7571.175', 'IU-2023.1':'231.8109.91', 'IU-2023.2':'232.8660.158', 'IU-2023.3':'233.11799.296', 'IU-2024.1':'241.14494.19']
 
 intellij {
     version = ideaVersion //for a full list of IntelliJ IDEA releases please see https://www.jetbrains.com/intellij-repository/releases

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-ideaVersion=IU-2023.3
+ideaVersion=IU-2024.1
 projectVersion=1.4.2
 jetBrainsToken=invalid
 jetBrainsChannel=stable

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -225,7 +225,7 @@
 
 
   <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-  <idea-version since-build="222"/>
+  <idea-version since-build="223"/>
 
   <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
        on how to target different products -->

--- a/src/test/java/com/redhat/devtools/intellij/tektoncd/completion/GenericCompletionProviderTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/tektoncd/completion/GenericCompletionProviderTest.java
@@ -10,8 +10,13 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.tektoncd.completion;
 
+import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.testFramework.PlatformLiteFixture;
 import org.junit.Test;
 
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.intellij.testFramework.UsefulTestCase.assertOrderedEquals;
 import static org.junit.Assert.assertTrue;
@@ -51,7 +56,12 @@ public class GenericCompletionProviderTest extends BaseCompletionProviderTest{
     /////////////////////////////////////////////////////////
 
     public void testTaskCompletionWithoutAnyInput() {
-        assertTrue(getSuggestionsForFile("task1.yaml").isEmpty());
+        List<String> suggestions = getSuggestionsForFile("task1.yaml");
+        if (getIDEAVersion() >= 2024.1f) {
+            assertOrderedEquals(suggestions, "apiVersion"); // default completion returns 'apiVersion'
+        } else {
+            assertTrue(suggestions.isEmpty());
+        }
     }
 
     public void testTaskCompletionWithParams() {
@@ -87,4 +97,10 @@ public class GenericCompletionProviderTest extends BaseCompletionProviderTest{
     public String getTestDataPath() {
         return "src/test/resources/completion/generic";
     }
+
+    private Float getIDEAVersion() {
+        String version = ApplicationInfo.getInstance().getFullVersion();
+        return Float.parseFloat(version);
+    }
+
 }


### PR DESCRIPTION
Caused following change that requires `sinceIdea` to be bumped to `IU-2022.3`
https://github.com/redhat-developer/intellij-common/pull/219